### PR TITLE
(neo-retropad) Add full support for automatic overlay scaling

### DIFF
--- a/gamepads/neo-retropad/neo-retropad-clear.cfg
+++ b/gamepads/neo-retropad/neo-retropad-clear.cfg
@@ -2,48 +2,72 @@ overlays = 8
 
 overlay0_full_screen = true
 overlay0_normalized = true
+overlay0_aspect_ratio = 1.77820267686424474187
+overlay0_block_x_separation = false
+overlay0_block_y_separation = true
 overlay0_name = "landscape-digital"
 overlay0_range_mod = 1.5
 overlay0_alpha_mod = 2.0
 
 overlay1_full_screen = true
 overlay1_normalized = true
+overlay1_aspect_ratio = 1.77820267686424474187
+overlay1_block_x_separation = false
+overlay1_block_y_separation = true
 overlay1_name = "landscape-analog"
 overlay1_range_mod = 1.5
 overlay1_alpha_mod = 2.0
 
 overlay2_full_screen = true
 overlay2_normalized = true
+overlay2_aspect_ratio = 1.77820267686424474187
+overlay2_block_x_separation = false
+overlay2_block_y_separation = true
 overlay2_name = "landscape-hidden-digital"
 overlay2_range_mod = 1.5
 overlay2_alpha_mod = 2.0
 
 overlay3_full_screen = true
 overlay3_normalized = true
+overlay3_aspect_ratio = 1.77820267686424474187
+overlay3_block_x_separation = false
+overlay3_block_y_separation = true
 overlay3_name = "landscape-hidden-analog"
 overlay3_range_mod = 1.5
 overlay3_alpha_mod = 2.0
 
 overlay4_full_screen = true
 overlay4_normalized = true
+overlay4_aspect_ratio = 0.56236559139784946237
+overlay4_block_x_separation = false
+overlay4_block_y_separation = true
 overlay4_name = "portrait-digital"
 overlay4_range_mod = 1.5
 overlay4_alpha_mod = 2.0
 
 overlay5_full_screen = true
 overlay5_normalized = true
+overlay5_aspect_ratio = 0.56236559139784946237
+overlay5_block_x_separation = false
+overlay5_block_y_separation = true
 overlay5_name = "portrait-analog"
 overlay5_range_mod = 1.5
 overlay5_alpha_mod = 2.0
 
 overlay6_full_screen = true
 overlay6_normalized = true
+overlay6_aspect_ratio = 0.56236559139784946237
+overlay6_block_x_separation = false
+overlay6_block_y_separation = true
 overlay6_name = "portrait-hidden-digital"
 overlay6_range_mod = 1.5
 overlay6_alpha_mod = 2.0
 
 overlay7_full_screen = true
 overlay7_normalized = true
+overlay7_aspect_ratio = 0.56236559139784946237
+overlay7_block_x_separation = false
+overlay7_block_y_separation = true
 overlay7_name = "portrait-hidden-analog"
 overlay7_range_mod = 1.5
 overlay7_alpha_mod = 2.0

--- a/gamepads/neo-retropad/neo-retropad.cfg
+++ b/gamepads/neo-retropad/neo-retropad.cfg
@@ -2,48 +2,72 @@ overlays = 8
 
 overlay0_full_screen = true
 overlay0_normalized = true
+overlay0_aspect_ratio = 1.77820267686424474187
+overlay0_block_x_separation = false
+overlay0_block_y_separation = true
 overlay0_name = "landscape-digital"
 overlay0_range_mod = 1.5
 overlay0_alpha_mod = 2.0
 
 overlay1_full_screen = true
 overlay1_normalized = true
+overlay1_aspect_ratio = 1.77820267686424474187
+overlay1_block_x_separation = false
+overlay1_block_y_separation = true
 overlay1_name = "landscape-analog"
 overlay1_range_mod = 1.5
 overlay1_alpha_mod = 2.0
 
 overlay2_full_screen = true
 overlay2_normalized = true
+overlay2_aspect_ratio = 1.77820267686424474187
+overlay2_block_x_separation = false
+overlay2_block_y_separation = true
 overlay2_name = "landscape-hidden-digital"
 overlay2_range_mod = 1.5
 overlay2_alpha_mod = 2.0
 
 overlay3_full_screen = true
 overlay3_normalized = true
+overlay3_aspect_ratio = 1.77820267686424474187
+overlay3_block_x_separation = false
+overlay3_block_y_separation = true
 overlay3_name = "landscape-hidden-analog"
 overlay3_range_mod = 1.5
 overlay3_alpha_mod = 2.0
 
 overlay4_full_screen = true
 overlay4_normalized = true
+overlay4_aspect_ratio = 0.56236559139784946237
+overlay4_block_x_separation = false
+overlay4_block_y_separation = true
 overlay4_name = "portrait-digital"
 overlay4_range_mod = 1.5
 overlay4_alpha_mod = 2.0
 
 overlay5_full_screen = true
 overlay5_normalized = true
+overlay5_aspect_ratio = 0.56236559139784946237
+overlay5_block_x_separation = false
+overlay5_block_y_separation = true
 overlay5_name = "portrait-analog"
 overlay5_range_mod = 1.5
 overlay5_alpha_mod = 2.0
 
 overlay6_full_screen = true
 overlay6_normalized = true
+overlay6_aspect_ratio = 0.56236559139784946237
+overlay6_block_x_separation = false
+overlay6_block_y_separation = true
 overlay6_name = "portrait-hidden-digital"
 overlay6_range_mod = 1.5
 overlay6_alpha_mod = 2.0
 
 overlay7_full_screen = true
 overlay7_normalized = true
+overlay7_aspect_ratio = 0.56236559139784946237
+overlay7_block_x_separation = false
+overlay7_block_y_separation = true
 overlay7_name = "portrait-hidden-analog"
 overlay7_range_mod = 1.5
 overlay7_alpha_mod = 2.0


### PR DESCRIPTION
The PR updates the `neo-retropad` config files with the additional parameters required for correct operation with https://github.com/libretro/RetroArch/pull/11340