### PR TITLE
add combo key areas to neo-retropad

### DIFF
--- a/gamepads/neo-retropad/neo-retropad-clear.cfg
+++ b/gamepads/neo-retropad/neo-retropad-clear.cfg
@@ -73,7 +73,7 @@ overlay7_range_mod = 1.5
 overlay7_alpha_mod = 2.0
 
 ## Overlay 0: landscape-digital
-overlay0_descs = 29
+overlay0_descs = 37
 
 # D-Pad
 overlay0_desc0 = "down,0.09462365591397849107,0.64340344168260032998,radial,0.03440860215053763438,0.07552581261950286340"
@@ -171,8 +171,18 @@ overlay0_desc28 = "overlay_next,0.50000000000000000000,0.04397705544933078192,ra
 overlay0_desc28_next_target = "portrait-digital"
 #overlay0_desc28_overlay = "png/clear/test_64x64.png"
 
+# Combo buttons
+overlay0_desc29 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
+overlay0_desc30 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
+overlay0_desc31 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
+overlay0_desc32 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
+overlay0_desc33 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
+overlay0_desc34 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
+overlay0_desc35 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
+overlay0_desc36 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
+
 ## Overlay 1: landscape-analog
-overlay1_descs = 19
+overlay1_descs = 27
 
 # Analog stick
 overlay1_desc0 = "nul,0.09462365591397849107,0.55640535372848953788,radial,0.08709677419354838745,0.15487571701720842521"
@@ -243,6 +253,16 @@ overlay1_desc18 = "overlay_next,0.50000000000000000000,0.04397705544933078192,ra
 overlay1_desc18_next_target = "portrait-analog"
 #overlay1_desc18_overlay = "png/clear/test_64x64.png"
 
+# Combo buttons
+overlay1_desc19 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
+overlay1_desc20 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
+overlay1_desc21 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
+overlay1_desc22 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
+overlay1_desc23 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
+overlay1_desc24 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
+overlay1_desc25 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
+overlay1_desc26 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
+
 ## Overlay 2: landscape-hidden-digital
 overlay2_descs = 2
 
@@ -270,7 +290,7 @@ overlay3_desc1_next_target = "portrait-hidden-analog"
 #overlay3_desc1_overlay = "png/clear/test_64x64.png"
 
 ## Overlay 4: portrait-digital
-overlay4_descs = 29
+overlay4_descs = 37
 
 # D-Pad
 overlay4_desc0 = "down,0.21606118546845123896,0.68333333333333334814,radial,0.06118546845124282763,0.04247311827956989222"
@@ -368,8 +388,18 @@ overlay4_desc28 = "overlay_next,0.50000000000000000000,0.02473118279569892428,ra
 overlay4_desc28_next_target = "landscape-digital"
 #overlay4_desc28_overlay = "png/clear/test_64x64.png"
 
+# Combo buttons
+overlay4_desc29 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
+overlay4_desc30 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
+overlay4_desc31 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
+overlay4_desc32 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
+overlay4_desc33 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
+overlay4_desc34 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
+overlay4_desc35 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
+overlay4_desc36 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+
 ## Overlay 5: portrait-analog
-overlay5_descs = 19
+overlay5_descs = 27
 
 # Analog stick
 overlay5_desc0 = "nul,0.21606118546845123896,0.63440860215053762605,radial,0.15487571701720842521,0.08709677419354838745"
@@ -439,6 +469,16 @@ overlay5_desc17_overlay = "png/clear/hotkey_menu.png"
 overlay5_desc18 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
 overlay5_desc18_next_target = "landscape-analog"
 #overlay5_desc18_overlay = "png/clear/test_64x64.png"
+
+# Combo buttons
+overlay5_desc19 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
+overlay5_desc20 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
+overlay5_desc21 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
+overlay5_desc22 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
+overlay5_desc23 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
+overlay5_desc24 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
+overlay5_desc25 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
+overlay5_desc26 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
 
 ## Overlay 6: portrait-hidden-digital
 overlay6_descs = 2

--- a/gamepads/neo-retropad/neo-retropad.cfg
+++ b/gamepads/neo-retropad/neo-retropad.cfg
@@ -73,7 +73,7 @@ overlay7_range_mod = 1.5
 overlay7_alpha_mod = 2.0
 
 ## Overlay 0: landscape-digital
-overlay0_descs = 29
+overlay0_descs = 37
 
 # D-Pad
 overlay0_desc0 = "down,0.09462365591397849107,0.64340344168260032998,radial,0.03440860215053763438,0.07552581261950286340"
@@ -171,8 +171,18 @@ overlay0_desc28 = "overlay_next,0.50000000000000000000,0.04397705544933078192,ra
 overlay0_desc28_next_target = "portrait-digital"
 #overlay0_desc28_overlay = "png/default/test_64x64.png"
 
+# Combo buttons
+overlay0_desc29 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
+overlay0_desc30 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
+overlay0_desc31 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
+overlay0_desc32 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
+overlay0_desc33 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
+overlay0_desc34 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
+overlay0_desc35 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
+overlay0_desc36 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"                                                    
+
 ## Overlay 1: landscape-analog
-overlay1_descs = 19
+overlay1_descs = 27
 
 # Analog stick
 overlay1_desc0 = "nul,0.09462365591397849107,0.55640535372848953788,radial,0.08709677419354838745,0.15487571701720842521"
@@ -243,6 +253,16 @@ overlay1_desc18 = "overlay_next,0.50000000000000000000,0.04397705544933078192,ra
 overlay1_desc18_next_target = "portrait-analog"
 #overlay1_desc18_overlay = "png/default/test_64x64.png"
 
+# Combo buttons
+overlay1_desc19 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
+overlay1_desc20 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
+overlay1_desc21 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
+overlay1_desc22 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
+overlay1_desc23 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
+overlay1_desc24 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
+overlay1_desc25 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
+overlay1_desc26 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"                                                             
+
 ## Overlay 2: landscape-hidden-digital
 overlay2_descs = 2
 
@@ -270,7 +290,7 @@ overlay3_desc1_next_target = "portrait-hidden-analog"
 #overlay3_desc1_overlay = "png/default/test_64x64.png"
 
 ## Overlay 4: portrait-digital
-overlay4_descs = 29
+overlay4_descs = 37
 
 # D-Pad
 overlay4_desc0 = "down,0.21606118546845123896,0.68333333333333334814,radial,0.06118546845124282763,0.04247311827956989222"
@@ -368,8 +388,18 @@ overlay4_desc28 = "overlay_next,0.50000000000000000000,0.02473118279569892428,ra
 overlay4_desc28_next_target = "landscape-digital"
 #overlay4_desc28_overlay = "png/default/test_64x64.png"
 
+# Combo buttons
+overlay4_desc29 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
+overlay4_desc30 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
+overlay4_desc31 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
+overlay4_desc32 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
+overlay4_desc33 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
+overlay4_desc34 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
+overlay4_desc35 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
+overlay4_desc36 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+
 ## Overlay 5: portrait-analog
-overlay5_descs = 19
+overlay5_descs = 27
 
 # Analog stick
 overlay5_desc0 = "nul,0.21606118546845123896,0.63440860215053762605,radial,0.15487571701720842521,0.08709677419354838745"
@@ -439,6 +469,16 @@ overlay5_desc17_overlay = "png/default/hotkey_menu.png"
 overlay5_desc18 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
 overlay5_desc18_next_target = "landscape-analog"
 #overlay5_desc18_overlay = "png/default/test_64x64.png"
+
+# Combo buttons
+overlay5_desc19 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
+overlay5_desc20 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
+overlay5_desc21 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
+overlay5_desc22 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
+overlay5_desc23 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
+overlay5_desc24 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
+overlay5_desc25 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
+overlay5_desc26 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
 
 ## Overlay 6: portrait-hidden-digital
 overlay6_descs = 2


### PR DESCRIPTION
This was missing for neo-retropad: buttons combo between ABXY buttons.

![landscape](https://user-images.githubusercontent.com/6266038/116940988-20688480-ac6f-11eb-9950-4da33b2fbaea.png)

![portrait](https://user-images.githubusercontent.com/6266038/116940991-21011b00-ac6f-11eb-9f65-57f746d39114.png)

Thank you Cuttlefish OverlayEditor.

![cuttlefish](https://user-images.githubusercontent.com/6266038/116941372-d338e280-ac6f-11eb-9785-c3510cefbb9b.png)

