### PR TITLE
Add Makefile for packaged installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+# libretro-database
+#
+# This file provides some install and building commands for libretro-database.
+#
+# make install
+#     Installs the needed files to the given DESTDIR and INSTALLDIR.
+#
+# make build
+#     Builds the RDB files using libretro-super.
+
+PREFIX := /usr
+INSTALLDIR := $(PREFIX)/share/libretro/overlays
+
+all:
+	@echo "Nothing to make for libretro-overlays."
+
+install:
+	mkdir -p $(DESTDIR)$(INSTALLDIR)
+	cp -ar -t $(DESTDIR)$(INSTALLDIR) borders ctr effects gamepads ipad keyboards misc wii
+
+test-install: all
+	DESTDIR=/tmp/build $(MAKE) install

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,6 @@
 #
 # make install
 #     Installs the needed files to the given DESTDIR and INSTALLDIR.
-#
-# make build
-#     Builds the RDB files using libretro-super.
 
 PREFIX := /usr
 INSTALLDIR := $(PREFIX)/share/libretro/overlays

--- a/configure
+++ b/configure
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+PACKAGE_NAME=libretro-overlays


### PR DESCRIPTION
This adds a Makefile to allow installing the package through `make install`. Follows the same pattern for [libretro-database's Makefile](https://github.com/libretro/libretro-database/blob/master/Makefile), the assets, info files, autoconfig, etc.