### PR TITLE
Update neo-retropad to use new features

### DIFF
--- a/gamepads/neo-retropad/neo-retropad-clear.cfg
+++ b/gamepads/neo-retropad/neo-retropad-clear.cfg
@@ -73,195 +73,325 @@ overlay7_range_mod = 1.5
 overlay7_alpha_mod = 2.0
 
 ## Overlay 0: landscape-digital
-overlay0_descs = 37
+overlay0_descs = 39
 
 # D-Pad
-overlay0_desc0 = "down,0.09462365591397849107,0.64340344168260032998,radial,0.03440860215053763438,0.07552581261950286340"
-overlay0_desc0_overlay = "png/clear/dpad_down.png"
+overlay0_desc0 = "dpad_area,0.09462365591397849107,0.55640535372848953788,rect,0.089583,0.159259"
+overlay0_desc0_reach_x = 1.9
+overlay0_desc0_reach_y = 1.5
+overlay0_desc0_range_mod = 1.2
+overlay0_desc0_range_mod_exclusive = true
 
-overlay0_desc1 = "left,0.04569892473118279674,0.55640535372848953788,radial,0.04247311827956989222,0.06118546845124282763"
-overlay0_desc1_overlay = "png/clear/dpad_left.png"
+overlay0_desc1 = "down,0.09462365591397849107,0.64340344168260032998,rect,0.03440860215053763438,0.07552581261950286340"
+overlay0_desc1_overlay = "png/clear/dpad_down.png"
+overlay0_desc1_reach_x = 0
 
-overlay0_desc2 = "right,0.14354838709677419928,0.55640535372848953788,radial,0.04247311827956989222,0.06118546845124282763"
-overlay0_desc2_overlay = "png/clear/dpad_right.png"
+overlay0_desc2 = "left,0.04569892473118279674,0.55640535372848953788,rect,0.04247311827956989222,0.06118546845124282763"
+overlay0_desc2_overlay = "png/clear/dpad_left.png"
+overlay0_desc2_reach_x = 0
 
-overlay0_desc3 = "up,0.09462365591397849107,0.46940726577437857925,radial,0.03440860215053763438,0.07552581261950286340"
-overlay0_desc3_overlay = "png/clear/dpad_up.png"
+overlay0_desc3 = "right,0.14354838709677419928,0.55640535372848953788,rect,0.04247311827956989222,0.06118546845124282763"
+overlay0_desc3_overlay = "png/clear/dpad_right.png"
+overlay0_desc3_reach_x = 0
 
-overlay0_desc4 = "down,0.09462365591397849107,0.68116634799235176168,rect,0.03440860215053763438,0.03776290630975143170"
-#overlay0_desc4_overlay = "png/clear/test_64x64.png"
+overlay0_desc4 = "up,0.09462365591397849107,0.46940726577437857925,rect,0.03440860215053763438,0.07552581261950286340"
+overlay0_desc4_overlay = "png/clear/dpad_up.png"
+overlay0_desc4_reach_x = 0
 
-overlay0_desc5 = "left,0.02446236559139785063,0.55640535372848953788,rect,0.02123655913978494611,0.06118546845124282763"
+overlay0_desc5 = "down,0.09462365591397849107,0.68116634799235176168,rect,0.03440860215053763438,0.03776290630975143170"
 #overlay0_desc5_overlay = "png/clear/test_64x64.png"
+overlay0_desc5_reach_x = 0
 
-overlay0_desc6 = "right,0.16478494623655914886,0.55640535372848953788,rect,0.02123655913978494611,0.06118546845124282763"
+overlay0_desc6 = "left,0.02446236559139785063,0.55640535372848953788,rect,0.02123655913978494611,0.06118546845124282763"
 #overlay0_desc6_overlay = "png/clear/test_64x64.png"
+overlay0_desc6_reach_x = 0
 
-overlay0_desc7 = "up,0.09462365591397849107,0.43164435946462714755,rect,0.03440860215053763438,0.03776290630975143170"
+overlay0_desc7 = "right,0.16478494623655914886,0.55640535372848953788,rect,0.02123655913978494611,0.06118546845124282763"
 #overlay0_desc7_overlay = "png/clear/test_64x64.png"
+overlay0_desc7_reach_x = 0
 
-overlay0_desc8 = "down|left,0.02741935483870967805,0.67590822179732312769,rect,0.02419354838709677352,0.04302103250478011426"
+overlay0_desc8 = "up,0.09462365591397849107,0.43164435946462714755,rect,0.03440860215053763438,0.03776290630975143170"
 #overlay0_desc8_overlay = "png/clear/test_64x64.png"
+overlay0_desc8_reach_x = 0
 
-overlay0_desc9 = "down|right,0.16182795698924731798,0.67590822179732312769,rect,0.02419354838709677352,0.04302103250478011426"
+overlay0_desc9 = "down|left,0.02741935483870967805,0.67590822179732312769,rect,0.02419354838709677352,0.04302103250478011426"
 #overlay0_desc9_overlay = "png/clear/test_64x64.png"
+overlay0_desc9_reach_x = 0
 
-overlay0_desc10 = "up|left,0.02741935483870967805,0.43690248565965583705,rect,0.02419354838709677352,0.04302103250478011426"
+overlay0_desc10 = "down|right,0.16182795698924731798,0.67590822179732312769,rect,0.02419354838709677352,0.04302103250478011426"
 #overlay0_desc10_overlay = "png/clear/test_64x64.png"
+overlay0_desc10_reach_x = 0
 
-overlay0_desc11 = "up|right,0.16182795698924731798,0.43690248565965583705,rect,0.02419354838709677352,0.04302103250478011426"
+overlay0_desc11 = "up|left,0.02741935483870967805,0.43690248565965583705,rect,0.02419354838709677352,0.04302103250478011426"
 #overlay0_desc11_overlay = "png/clear/test_64x64.png"
+overlay0_desc11_reach_x = 0
+
+overlay0_desc12 = "up|right,0.16182795698924731798,0.43690248565965583705,rect,0.02419354838709677352,0.04302103250478011426"
+#overlay0_desc12_overlay = "png/clear/test_64x64.png"
+overlay0_desc12_reach_x = 0
 
 # ABXY
-overlay0_desc12 = "a,0.96236559139784949579,0.55640535372848953788,radial,0.03440860215053763438,0.06118546845124282763"
-overlay0_desc12_overlay = "png/clear/button_a.png"
+overlay0_desc13 = "abxy_area,0.90537634408602152281,0.55640535372848953788,rect,0.089583,0.159259"
+overlay0_desc13_reach_x = 1.4
+overlay0_desc13_reach_y = 1.4
+overlay0_desc13_range_mod = 1.1
+overlay0_desc13_range_mod_exclusive = true
 
-overlay0_desc13 = "b,0.90537634408602152281,0.65774378585086046289,radial,0.03440860215053763438,0.06118546845124282763"
-overlay0_desc13_overlay = "png/clear/button_b.png"
+overlay0_desc14 = "a,0.96236559139784949579,0.55640535372848953788,rect,0.03440860215053763438,0.06118546845124282763"
+overlay0_desc14_overlay = "png/clear/button_a.png"
+overlay0_desc14_reach_x = 0
 
-overlay0_desc14 = "x,0.90537634408602152281,0.45506692160611855735,radial,0.03440860215053763438,0.06118546845124282763"
-overlay0_desc14_overlay = "png/clear/button_x.png"
+overlay0_desc15 = "b,0.90537634408602152281,0.65774378585086046289,rect,0.03440860215053763438,0.06118546845124282763"
+overlay0_desc15_overlay = "png/clear/button_b.png"
+overlay0_desc15_reach_x = 0
 
-overlay0_desc15 = "y,0.84838709677419354982,0.55640535372848953788,radial,0.03440860215053763438,0.06118546845124282763"
-overlay0_desc15_overlay = "png/clear/button_y.png"
+overlay0_desc16 = "x,0.90537634408602152281,0.45506692160611855735,rect,0.03440860215053763438,0.06118546845124282763"
+overlay0_desc16_overlay = "png/clear/button_x.png"
+overlay0_desc16_reach_x = 0
+
+overlay0_desc17 = "y,0.84838709677419354982,0.55640535372848953788,rect,0.03440860215053763438,0.06118546845124282763"
+overlay0_desc17_overlay = "png/clear/button_y.png"
+overlay0_desc17_reach_x = 0
 
 # Select/start
-overlay0_desc16 = "select,0.03333333333333333287,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
-overlay0_desc16_overlay = "png/clear/button_select.png"
+overlay0_desc18 = "select,0.03333333333333333287,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
+overlay0_desc18_overlay = "png/clear/button_select.png"
+overlay0_desc18_reach_x = 1.2
+overlay0_desc18_reach_up = 2.0
+overlay0_desc18_reach_down = 1.6
+overlay0_desc18_exclusive = true
 
-overlay0_desc17 = "start,0.96666666666666667407,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
-overlay0_desc17_overlay = "png/clear/button_start.png"
+overlay0_desc19 = "start,0.96666666666666667407,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
+overlay0_desc19_overlay = "png/clear/button_start.png"
+overlay0_desc19_reach_x = 1.2
+overlay0_desc19_reach_up = 2.0
+overlay0_desc19_reach_down = 1.6
+overlay0_desc19_exclusive = true
 
 # L/R buttons
-overlay0_desc18 = "l,0.03333333333333333287,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc18_overlay = "png/clear/button_l1.png"
+overlay0_desc20 = "l,0.03333333333333333287,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc20_overlay = "png/clear/button_l1.png"
+overlay0_desc20_reach_x = 1.2
+overlay0_desc20_reach_down = 1.8
+overlay0_desc20_reach_up = 1.5
+overlay0_desc20_exclusive = true
 
-overlay0_desc19 = "l2,0.03333333333333333287,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc19_overlay = "png/clear/button_l2.png"
+overlay0_desc21 = "l2,0.03333333333333333287,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc21_overlay = "png/clear/button_l2.png"
+overlay0_desc21_reach_x = 2.0
+overlay0_desc21_reach_y = 1.5
+overlay0_desc21_exclusive = true
 
-overlay0_desc20 = "l3,0.03333333333333333287,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc20_overlay = "png/clear/button_l3.png"
+overlay0_desc22 = "l3,0.03333333333333333287,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc22_overlay = "png/clear/button_l3.png"
+overlay0_desc22_reach_x = 2.0
+overlay0_desc22_reach_y = 1.5
+overlay0_desc22_exclusive = true
 
-overlay0_desc21 = "r,0.96666666666666667407,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc21_overlay = "png/clear/button_r1.png"
+overlay0_desc23 = "r,0.96666666666666667407,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc23_overlay = "png/clear/button_r1.png"
+overlay0_desc23_reach_x = 1.2
+overlay0_desc23_reach_down = 1.8
+overlay0_desc23_reach_up = 1.5
+overlay0_desc23_exclusive = true
 
-overlay0_desc22 = "r2,0.96666666666666667407,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc22_overlay = "png/clear/button_r2.png"
+overlay0_desc24 = "r2,0.96666666666666667407,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc24_overlay = "png/clear/button_r2.png"
+overlay0_desc24_reach_x = 2.0
+overlay0_desc24_reach_y = 1.5
+overlay0_desc24_exclusive = true
 
-overlay0_desc23 = "r3,0.96666666666666667407,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc23_overlay = "png/clear/button_r3.png"
+overlay0_desc25 = "r3,0.96666666666666667407,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc25_overlay = "png/clear/button_r3.png"
+overlay0_desc25_reach_x = 2.0
+overlay0_desc25_reach_y = 1.5
+overlay0_desc25_exclusive = true
 
 # Hotkeys
-overlay0_desc24 = "overlay_next,0.02473118279569892428,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc24_next_target = "landscape-analog"
-overlay0_desc24_overlay = "png/clear/hotkey_analog.png"
+overlay0_desc26 = "overlay_next,0.02473118279569892428,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc26_next_target = "landscape-analog"
+overlay0_desc26_overlay = "png/clear/hotkey_analog.png"
+overlay0_desc26_reach_x = 1.6
+overlay0_desc26_reach_y = 1.6
 
-overlay0_desc25 = "toggle_fast_forward,0.09354838709677419650,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc25_overlay = "png/clear/hotkey_fast_forward.png"
+overlay0_desc27 = "toggle_fast_forward,0.09354838709677419650,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc27_overlay = "png/clear/hotkey_fast_forward.png"
+overlay0_desc27_reach_x = 1.6
+overlay0_desc27_reach_y = 1.6
 
-overlay0_desc26 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc26_next_target = "landscape-hidden-digital"
-overlay0_desc26_overlay = "png/clear/hotkey_hide.png"
+overlay0_desc28 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc28_next_target = "landscape-hidden-digital"
+overlay0_desc28_overlay = "png/clear/hotkey_hide.png"
+overlay0_desc28_reach_x = 1.6
+overlay0_desc28_reach_y = 1.6
 
-overlay0_desc27 = "menu_toggle,0.90645161290322584513,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc27_overlay = "png/clear/hotkey_menu.png"
+overlay0_desc29 = "menu_toggle,0.90645161290322584513,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc29_overlay = "png/clear/hotkey_menu.png"
+overlay0_desc29_reach_x = 1.6
+overlay0_desc29_reach_y = 1.6
 
 # Invisible rotate hotkey
-overlay0_desc28 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc28_next_target = "portrait-digital"
-#overlay0_desc28_overlay = "png/clear/test_64x64.png"
+overlay0_desc30 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc30_next_target = "portrait-digital"
+#overlay0_desc30_overlay = "png/clear/test_64x64.png"
 
 # Combo buttons
-overlay0_desc29 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
-overlay0_desc30 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
-overlay0_desc31 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
-overlay0_desc32 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
-overlay0_desc33 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
-overlay0_desc34 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
-overlay0_desc35 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
-overlay0_desc36 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
+overlay0_desc31 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
+overlay0_desc31_reach_x = 0
+overlay0_desc32 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
+overlay0_desc32_reach_x = 0
+overlay0_desc33 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
+overlay0_desc33_reach_x = 0
+overlay0_desc34 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
+overlay0_desc34_reach_x = 0
+overlay0_desc35 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
+overlay0_desc35_reach_x = 0
+overlay0_desc36 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
+overlay0_desc36_reach_x = 0
+overlay0_desc37 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
+overlay0_desc37_reach_x = 0
+overlay0_desc38 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
+overlay0_desc38_reach_x = 0
 
 ## Overlay 1: landscape-analog
-overlay1_descs = 27
+overlay1_descs = 20
 
 # Analog stick
-overlay1_desc0 = "nul,0.09462365591397849107,0.55640535372848953788,radial,0.08709677419354838745,0.15487571701720842521"
+overlay1_desc0 = "analog_left,0.09462365591397849107,0.55640535372848953788,radial,0.08709677419354838745,0.15487571701720842521"
 overlay1_desc0_overlay = "png/clear/analog_bg.png"
+overlay1_desc0_saturate_pct = 1000000.0
+overlay1_desc0_reach_x = 0
 
 overlay1_desc1 = "analog_left,0.09462365591397849107,0.55640535372848953788,radial,0.05053763440860215006,0.08986615678776291305"
-overlay1_desc1_range_mod = 4.0
-overlay1_desc1_pct = 0.75
-overlay1_desc1_movable = true
 overlay1_desc1_overlay = "png/clear/analog_stick.png"
+overlay1_desc1_movable = true
+overlay1_desc1_reach_x = 1.75
+overlay1_desc1_reach_y = 1.75
+overlay1_desc1_range_mod = 4.0
+overlay1_desc1_range_mod_exclusive = true
 
 # ABXY
-overlay1_desc2 = "a,0.96236559139784949579,0.55640535372848953788,radial,0.03440860215053763438,0.06118546845124282763"
-overlay1_desc2_overlay = "png/clear/button_a.png"
+overlay1_desc2 = "abxy_area,0.90537634408602152281,0.55640535372848953788,rect,0.089583,0.159259"
+overlay1_desc2_reach_x = 1.4
+overlay1_desc2_reach_y = 1.4
+overlay1_desc2_range_mod = 1.1
+overlay1_desc2_range_mod_exclusive = true
 
-overlay1_desc3 = "b,0.90537634408602152281,0.65774378585086046289,radial,0.03440860215053763438,0.06118546845124282763"
-overlay1_desc3_overlay = "png/clear/button_b.png"
+overlay1_desc3 = "a,0.96236559139784949579,0.55640535372848953788,rect,0.03440860215053763438,0.06118546845124282763"
+overlay1_desc3_overlay = "png/clear/button_a.png"
+overlay1_desc3_reach_x = 0
 
-overlay1_desc4 = "x,0.90537634408602152281,0.45506692160611855735,radial,0.03440860215053763438,0.06118546845124282763"
-overlay1_desc4_overlay = "png/clear/button_x.png"
+overlay1_desc4 = "b,0.90537634408602152281,0.65774378585086046289,rect,0.03440860215053763438,0.06118546845124282763"
+overlay1_desc4_overlay = "png/clear/button_b.png"
+overlay1_desc4_reach_x = 0
 
-overlay1_desc5 = "y,0.84838709677419354982,0.55640535372848953788,radial,0.03440860215053763438,0.06118546845124282763"
-overlay1_desc5_overlay = "png/clear/button_y.png"
+overlay1_desc5 = "x,0.90537634408602152281,0.45506692160611855735,rect,0.03440860215053763438,0.06118546845124282763"
+overlay1_desc5_overlay = "png/clear/button_x.png"
+overlay1_desc5_reach_x = 0
+
+overlay1_desc6 = "y,0.84838709677419354982,0.55640535372848953788,rect,0.03440860215053763438,0.06118546845124282763"
+overlay1_desc6_overlay = "png/clear/button_y.png"
+overlay1_desc6_reach_x = 0
 
 # Select/start
-overlay1_desc6 = "select,0.03333333333333333287,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
-overlay1_desc6_overlay = "png/clear/button_select.png"
+overlay1_desc7 = "select,0.03333333333333333287,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
+overlay1_desc7_overlay = "png/clear/button_select.png"
+overlay1_desc7_reach_x = 1.2
+overlay1_desc7_reach_up = 2.0
+overlay1_desc7_reach_down = 1.6
+overlay1_desc7_exclusive = true
 
-overlay1_desc7 = "start,0.96666666666666667407,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
-overlay1_desc7_overlay = "png/clear/button_start.png"
+overlay1_desc8 = "start,0.96666666666666667407,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
+overlay1_desc8_overlay = "png/clear/button_start.png"
+overlay1_desc8_reach_x = 1.2
+overlay1_desc8_reach_up = 2.0
+overlay1_desc8_reach_down = 1.6
+overlay1_desc8_exclusive = true
 
 # L/R buttons
-overlay1_desc8 = "l,0.03333333333333333287,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc8_overlay = "png/clear/button_l1.png"
+overlay1_desc9 = "l,0.03333333333333333287,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc9_overlay = "png/clear/button_l1.png"
+overlay1_desc9_reach_x = 1.2
+overlay1_desc9_reach_down = 1.8
+overlay1_desc9_reach_up = 1.5
+overlay1_desc9_exclusive = true
 
-overlay1_desc9 = "l2,0.03333333333333333287,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc9_overlay = "png/clear/button_l2.png"
+overlay1_desc10 = "l2,0.03333333333333333287,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc10_overlay = "png/clear/button_l2.png"
+overlay1_desc10_reach_x = 2.0
+overlay1_desc10_reach_y = 1.5
+overlay1_desc10_exclusive = true
 
-overlay1_desc10 = "l3,0.03333333333333333287,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc10_overlay = "png/clear/button_l3.png"
+overlay1_desc11 = "l3,0.03333333333333333287,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc11_overlay = "png/clear/button_l3.png"
+overlay1_desc11_reach_x = 2.0
+overlay1_desc11_reach_y = 1.5
+overlay1_desc11_exclusive = true
 
-overlay1_desc11 = "r,0.96666666666666667407,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc11_overlay = "png/clear/button_r1.png"
+overlay1_desc12 = "r,0.96666666666666667407,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc12_overlay = "png/clear/button_r1.png"
+overlay1_desc12_reach_x = 1.2
+overlay1_desc12_reach_down = 1.8
+overlay1_desc12_reach_up = 1.5
+overlay1_desc12_exclusive = true
 
-overlay1_desc12 = "r2,0.96666666666666667407,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc12_overlay = "png/clear/button_r2.png"
+overlay1_desc13 = "r2,0.96666666666666667407,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc13_overlay = "png/clear/button_r2.png"
+overlay1_desc13_reach_x = 2.0
+overlay1_desc13_reach_y = 1.5
+overlay1_desc13_exclusive = true
 
-overlay1_desc13 = "r3,0.96666666666666667407,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc13_overlay = "png/clear/button_r3.png"
+overlay1_desc14 = "r3,0.96666666666666667407,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc14_overlay = "png/clear/button_r3.png"
+overlay1_desc14_reach_x = 2.0
+overlay1_desc14_reach_y = 1.5
+overlay1_desc14_exclusive = true
 
 # Hotkeys
-overlay1_desc14 = "overlay_next,0.02473118279569892428,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc14_next_target = "landscape-digital"
-overlay1_desc14_overlay = "png/clear/hotkey_digital.png"
+overlay1_desc15 = "overlay_next,0.02473118279569892428,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc15_next_target = "landscape-digital"
+overlay1_desc15_overlay = "png/clear/hotkey_digital.png"
+overlay1_desc15_reach_x = 1.6
+overlay1_desc15_reach_y = 1.6
 
-overlay1_desc15 = "toggle_fast_forward,0.09354838709677419650,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc15_overlay = "png/clear/hotkey_fast_forward.png"
+overlay1_desc16 = "toggle_fast_forward,0.09354838709677419650,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc16_overlay = "png/clear/hotkey_fast_forward.png"
+overlay1_desc16_reach_x = 1.6
+overlay1_desc16_reach_y = 1.6
 
-overlay1_desc16 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc16_next_target = "landscape-hidden-analog"
-overlay1_desc16_overlay = "png/clear/hotkey_hide.png"
+overlay1_desc17 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc17_next_target = "landscape-hidden-analog"
+overlay1_desc17_overlay = "png/clear/hotkey_hide.png"
+overlay1_desc17_reach_x = 1.6
+overlay1_desc17_reach_y = 1.6
 
-overlay1_desc17 = "menu_toggle,0.90645161290322584513,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc17_overlay = "png/clear/hotkey_menu.png"
+overlay1_desc18 = "menu_toggle,0.90645161290322584513,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc18_overlay = "png/clear/hotkey_menu.png"
+overlay1_desc18_reach_x = 1.6
+overlay1_desc18_reach_y = 1.6
 
 # Invisible rotate hotkey
-overlay1_desc18 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc18_next_target = "portrait-analog"
-#overlay1_desc18_overlay = "png/clear/test_64x64.png"
+overlay1_desc19 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc19_next_target = "portrait-analog"
+#overlay1_desc19_overlay = "png/clear/test_64x64.png"
 
 # Combo buttons
-overlay1_desc19 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
-overlay1_desc20 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
-overlay1_desc21 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
-overlay1_desc22 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
-overlay1_desc23 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
-overlay1_desc24 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
-overlay1_desc25 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
-overlay1_desc26 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
+overlay1_desc20 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
+overlay1_desc20_reach_x = 0
+overlay1_desc21 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
+overlay1_desc21_reach_x = 0
+overlay1_desc22 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
+overlay1_desc22_reach_x = 0
+overlay1_desc23 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
+overlay1_desc23_reach_x = 0
+overlay1_desc24 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
+overlay1_desc24_reach_x = 0
+overlay1_desc25 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
+overlay1_desc25_reach_x = 0
+overlay1_desc26 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
+overlay1_desc26_reach_x = 0
+overlay1_desc27 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
+overlay1_desc27_reach_x = 0
 
 ## Overlay 2: landscape-hidden-digital
 overlay2_descs = 2
@@ -270,6 +400,8 @@ overlay2_descs = 2
 overlay2_desc0 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
 overlay2_desc0_next_target = "landscape-digital"
 overlay2_desc0_overlay = "png/clear/hotkey_show.png"
+overlay2_desc0_reach_x = 1.6
+overlay2_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
 overlay2_desc1 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
@@ -283,6 +415,8 @@ overlay3_descs = 2
 overlay3_desc0 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
 overlay3_desc0_next_target = "landscape-analog"
 overlay3_desc0_overlay = "png/clear/hotkey_show.png"
+overlay3_desc0_reach_x = 1.6
+overlay3_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
 overlay3_desc1 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
@@ -290,195 +424,319 @@ overlay3_desc1_next_target = "portrait-hidden-analog"
 #overlay3_desc1_overlay = "png/clear/test_64x64.png"
 
 ## Overlay 4: portrait-digital
-overlay4_descs = 37
+overlay4_descs = 39
 
 # D-Pad
-overlay4_desc0 = "down,0.21606118546845123896,0.68333333333333334814,radial,0.06118546845124282763,0.04247311827956989222"
-overlay4_desc0_overlay = "png/clear/dpad_down.png"
+overlay4_desc0 = "dpad_area,0.21606118546845123896,0.63440860215053762605,rect,0.159259,0.089583"
+overlay4_desc0_reach_x = 1.9
+overlay4_desc0_reach_y = 1.5
+overlay4_desc0_range_mod = 1.1
+overlay4_desc0_range_mod_exclusive = true
 
-overlay4_desc1 = "left,0.12906309751434033584,0.63440860215053762605,radial,0.07552581261950286340,0.03440860215053763438"
-overlay4_desc1_overlay = "png/clear/dpad_left.png"
+overlay4_desc1 = "down,0.21606118546845123896,0.68333333333333334814,rect,0.06118546845124282763,0.04247311827956989222"
+overlay4_desc1_overlay = "png/clear/dpad_down.png"
+overlay4_desc1_reach_x = 0
 
-overlay4_desc2 = "right,0.30305927342256211432,0.63440860215053762605,radial,0.07552581261950286340,0.03440860215053763438"
-overlay4_desc2_overlay = "png/clear/dpad_right.png"
+overlay4_desc2 = "left,0.12906309751434033584,0.63440860215053762605,rect,0.07552581261950286340,0.03440860215053763438"
+overlay4_desc2_overlay = "png/clear/dpad_left.png"
+overlay4_desc2_reach_x = 0
 
-overlay4_desc3 = "up,0.21606118546845123896,0.58548387096774190397,radial,0.06118546845124282763,0.04247311827956989222"
-overlay4_desc3_overlay = "png/clear/dpad_up.png"
+overlay4_desc3 = "right,0.30305927342256211432,0.63440860215053762605,rect,0.07552581261950286340,0.03440860215053763438"
+overlay4_desc3_overlay = "png/clear/dpad_right.png"
+overlay4_desc3_reach_x = 0
 
-overlay4_desc4 = "down,0.21606118546845123896,0.70456989247311829772,rect,0.06118546845124282763,0.02123655913978494611"
-#overlay4_desc4_overlay = "png/clear/test_64x64.png"
+overlay4_desc4 = "up,0.21606118546845123896,0.58548387096774190397,rect,0.06118546845124282763,0.04247311827956989222"
+overlay4_desc4_overlay = "png/clear/dpad_up.png"
+overlay4_desc4_reach_x = 0
 
-overlay4_desc5 = "left,0.09130019120458890414,0.63440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
+overlay4_desc5 = "down,0.21606118546845123896,0.70456989247311829772,rect,0.06118546845124282763,0.02123655913978494611"
 #overlay4_desc5_overlay = "png/clear/test_64x64.png"
+overlay4_desc5_reach_x = 0
 
-overlay4_desc6 = "right,0.34082217973231360153,0.63440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
+overlay4_desc6 = "left,0.09130019120458890414,0.63440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
 #overlay4_desc6_overlay = "png/clear/test_64x64.png"
+overlay4_desc6_reach_x = 0
 
-overlay4_desc7 = "up,0.21606118546845123896,0.56424731182795695439,rect,0.06118546845124282763,0.02123655913978494611"
+overlay4_desc7 = "right,0.34082217973231360153,0.63440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
 #overlay4_desc7_overlay = "png/clear/test_64x64.png"
+overlay4_desc7_reach_x = 0
 
-overlay4_desc8 = "down|left,0.09655831739961759363,0.70161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
+overlay4_desc8 = "up,0.21606118546845123896,0.56424731182795695439,rect,0.06118546845124282763,0.02123655913978494611"
 #overlay4_desc8_overlay = "png/clear/test_64x64.png"
+overlay4_desc8_reach_x = 0
 
-overlay4_desc9 = "down|right,0.33556405353728491203,0.70161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
+overlay4_desc9 = "down|left,0.09655831739961759363,0.70161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
 #overlay4_desc9_overlay = "png/clear/test_64x64.png"
+overlay4_desc9_reach_x = 0
 
-overlay4_desc10 = "up|left,0.09655831739961759363,0.56720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
+overlay4_desc10 = "down|right,0.33556405353728491203,0.70161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
 #overlay4_desc10_overlay = "png/clear/test_64x64.png"
+overlay4_desc10_reach_x = 0
 
-overlay4_desc11 = "up|right,0.33556405353728491203,0.56720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
+overlay4_desc11 = "up|left,0.09655831739961759363,0.56720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
 #overlay4_desc11_overlay = "png/clear/test_64x64.png"
+overlay4_desc11_reach_x = 0
+
+overlay4_desc12 = "up|right,0.33556405353728491203,0.56720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
+#overlay4_desc12_overlay = "png/clear/test_64x64.png"
+overlay4_desc12_reach_x = 0
 
 # ABXY
-overlay4_desc12 = "a,0.88527724665391971381,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
-overlay4_desc12_overlay = "png/clear/button_a.png"
+overlay4_desc13 = "abxy_area,0.78393881453154878880,0.63440860215053762605,rect,0.159259,0.089583"
+overlay4_desc13_reach_x = 1.4
+overlay4_desc13_reach_y = 1.4
+overlay4_desc13_range_mod = 1.1
+overlay4_desc13_range_mod_exclusive = true
 
-overlay4_desc13 = "b,0.78393881453154878880,0.69139784946236559904,radial,0.06118546845124282763,0.03440860215053763438"
-overlay4_desc13_overlay = "png/clear/button_b.png"
+overlay4_desc14 = "a,0.88527724665391971381,0.63440860215053762605,rect,0.06118546845124282763,0.03440860215053763438"
+overlay4_desc14_overlay = "png/clear/button_a.png"
+overlay4_desc14_reach_x = 0
 
-overlay4_desc14 = "x,0.78393881453154878880,0.57741935483870965307,radial,0.06118546845124282763,0.03440860215053763438"
-overlay4_desc14_overlay = "png/clear/button_x.png"
+overlay4_desc15 = "b,0.78393881453154878880,0.69139784946236559904,rect,0.06118546845124282763,0.03440860215053763438"
+overlay4_desc15_overlay = "png/clear/button_b.png"
+overlay4_desc15_reach_x = 0
 
-overlay4_desc15 = "y,0.68260038240917786379,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
-overlay4_desc15_overlay = "png/clear/button_y.png"
+overlay4_desc16 = "x,0.78393881453154878880,0.57741935483870965307,rect,0.06118546845124282763,0.03440860215053763438"
+overlay4_desc16_overlay = "png/clear/button_x.png"
+overlay4_desc16_reach_x = 0
+
+overlay4_desc17 = "y,0.68260038240917786379,0.63440860215053762605,rect,0.06118546845124282763,0.03440860215053763438"
+overlay4_desc17_overlay = "png/clear/button_y.png"
+overlay4_desc17_reach_x = 0
 
 # Select/start
-overlay4_desc16 = "select,0.40057361376673039643,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
-overlay4_desc16_overlay = "png/clear/button_select.png"
+overlay4_desc18 = "select,0.40057361376673039643,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
+overlay4_desc18_overlay = "png/clear/button_select.png"
+overlay4_desc18_reach_x = 1.2
+overlay4_desc18_reach_y = 1.6
+overlay4_desc18_exclusive = true
 
-overlay4_desc17 = "start,0.59942638623326960357,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
-overlay4_desc17_overlay = "png/clear/button_start.png"
+overlay4_desc19 = "start,0.59942638623326960357,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
+overlay4_desc19_overlay = "png/clear/button_start.png"
+overlay4_desc19_reach_x = 1.2
+overlay4_desc19_reach_y = 1.6
+overlay4_desc19_exclusive = true
 
 # L/R buttons
-overlay4_desc18 = "l,0.06883365200764818281,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc18_overlay = "png/clear/button_l1.png"
+overlay4_desc20 = "l,0.06883365200764818281,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc20_overlay = "png/clear/button_l1.png"
+overlay4_desc20_reach_x = 1.2
+overlay4_desc20_reach_y = 2.0
+overlay4_desc20_exclusive = true
 
-overlay4_desc19 = "l2,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc19_overlay = "png/clear/button_l2.png"
+overlay4_desc21 = "l2,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc21_overlay = "png/clear/button_l2.png"
+overlay4_desc21_reach_x = 1.6
+overlay4_desc21_reach_y = 2.0
+overlay4_desc21_exclusive = true
 
-overlay4_desc20 = "l3,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc20_overlay = "png/clear/button_l3.png"
+overlay4_desc22 = "l3,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc22_overlay = "png/clear/button_l3.png"
+overlay4_desc22_reach_x = 1.6
+overlay4_desc22_reach_y = 2.0
+overlay4_desc22_exclusive = true
 
-overlay4_desc21 = "r,0.93116634799235176168,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc21_overlay = "png/clear/button_r1.png"
+overlay4_desc23 = "r,0.93116634799235176168,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc23_overlay = "png/clear/button_r1.png"
+overlay4_desc23_reach_x = 1.2
+overlay4_desc23_reach_y = 2.0
+overlay4_desc23_exclusive = true
 
-overlay4_desc22 = "r2,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc22_overlay = "png/clear/button_r2.png"
+overlay4_desc24 = "r2,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc24_overlay = "png/clear/button_r2.png"
+overlay4_desc24_reach_x = 1.6
+overlay4_desc24_reach_y = 2.0
+overlay4_desc24_exclusive = true
 
-overlay4_desc23 = "r3,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc23_overlay = "png/clear/button_r3.png"
+overlay4_desc25 = "r3,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc25_overlay = "png/clear/button_r3.png"
+overlay4_desc25_reach_x = 1.6
+overlay4_desc25_reach_y = 2.0
+overlay4_desc25_exclusive = true
 
 # Hotkeys
-overlay4_desc24 = "overlay_next,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc24_next_target = "portrait-analog"
-overlay4_desc24_overlay = "png/clear/hotkey_analog.png"
+overlay4_desc26 = "overlay_next,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc26_next_target = "portrait-analog"
+overlay4_desc26_overlay = "png/clear/hotkey_analog.png"
+overlay4_desc26_reach_x = 1.6
+overlay4_desc26_reach_y = 1.6
 
-overlay4_desc25 = "toggle_fast_forward,0.94646271510516255532,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc25_overlay = "png/clear/hotkey_fast_forward.png"
+overlay4_desc27 = "toggle_fast_forward,0.94646271510516255532,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc27_overlay = "png/clear/hotkey_fast_forward.png"
+overlay4_desc27_reach_x = 1.6
+overlay4_desc27_reach_y = 1.6
 
-overlay4_desc26 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc26_next_target = "portrait-hidden-digital"
-overlay4_desc26_overlay = "png/clear/hotkey_hide.png"
+overlay4_desc28 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc28_next_target = "portrait-hidden-digital"
+overlay4_desc28_overlay = "png/clear/hotkey_hide.png"
+overlay4_desc28_reach_x = 1.6
+overlay4_desc28_reach_y = 1.6
 
-overlay4_desc27 = "menu_toggle,0.53824091778202676206,0.56451612903225811824,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc27_overlay = "png/clear/hotkey_menu.png"
+overlay4_desc29 = "menu_toggle,0.53824091778202676206,0.56451612903225811824,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc29_overlay = "png/clear/hotkey_menu.png"
+overlay4_desc29_reach_x = 1.6
+overlay4_desc29_reach_y = 1.6
+overlay4_desc29_exclusive = true
 
 # Invisible rotate hotkey
-overlay4_desc28 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc28_next_target = "landscape-digital"
-#overlay4_desc28_overlay = "png/clear/test_64x64.png"
+overlay4_desc30 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc30_next_target = "landscape-digital"
+#overlay4_desc30_overlay = "png/clear/test_64x64.png"
 
 # Combo buttons
-overlay4_desc29 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
-overlay4_desc30 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
-overlay4_desc31 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
-overlay4_desc32 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
-overlay4_desc33 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
-overlay4_desc34 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
-overlay4_desc35 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
-overlay4_desc36 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+overlay4_desc31 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
+overlay4_desc31_reach_x = 0
+overlay4_desc32 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
+overlay4_desc32_reach_x = 0
+overlay4_desc33 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
+overlay4_desc33_reach_x = 0
+overlay4_desc34 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
+overlay4_desc34_reach_x = 0
+overlay4_desc35 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
+overlay4_desc35_reach_x = 0
+overlay4_desc36 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
+overlay4_desc36_reach_x = 0
+overlay4_desc37 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
+overlay4_desc37_reach_x = 0
+overlay4_desc38 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+overlay4_desc38_reach_x = 0
 
 ## Overlay 5: portrait-analog
-overlay5_descs = 27
+overlay5_descs = 28
 
 # Analog stick
-overlay5_desc0 = "nul,0.21606118546845123896,0.63440860215053762605,radial,0.15487571701720842521,0.08709677419354838745"
+overlay5_desc0 = "analog_left,0.21606118546845123896,0.63440860215053762605,radial,0.15487571701720842521,0.08709677419354838745"
 overlay5_desc0_overlay = "png/clear/analog_bg.png"
+overlay5_desc0_saturate_pct = 1000000.0
+overlay5_desc0_reach_x = 0
 
 overlay5_desc1 = "analog_left,0.21606118546845123896,0.63440860215053762605,radial,0.08986615678776291305,0.05053763440860215006"
-overlay5_desc1_range_mod = 4.0
-overlay5_desc1_pct = 0.75
-overlay5_desc1_movable = true
 overlay5_desc1_overlay = "png/clear/analog_stick.png"
+overlay5_desc1_movable = true
+overlay5_desc1_reach_x = 1.3
+overlay5_desc1_reach_y = 1.3
+overlay5_desc1_range_mod = 3.0
+overlay5_desc1_range_mod_exclusive = true
 
 # ABXY
-overlay5_desc2 = "a,0.88527724665391971381,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
-overlay5_desc2_overlay = "png/clear/button_a.png"
+overlay5_desc2 = "abxy_area,0.78393881453154878880,0.63440860215053762605,rect,0.159259,0.089583"
+overlay5_desc2_reach_x = 1.4
+overlay5_desc2_reach_y = 1.4
+overlay5_desc2_range_mod = 1.1
+overlay5_desc2_range_mod_exclusive = true
 
-overlay5_desc3 = "b,0.78393881453154878880,0.69139784946236559904,radial,0.06118546845124282763,0.03440860215053763438"
-overlay5_desc3_overlay = "png/clear/button_b.png"
+overlay5_desc3 = "a,0.88527724665391971381,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
+overlay5_desc3_overlay = "png/clear/button_a.png"
+overlay5_desc3_reach_x = 0
 
-overlay5_desc4 = "x,0.78393881453154878880,0.57741935483870965307,radial,0.06118546845124282763,0.03440860215053763438"
-overlay5_desc4_overlay = "png/clear/button_x.png"
+overlay5_desc4 = "b,0.78393881453154878880,0.69139784946236559904,radial,0.06118546845124282763,0.03440860215053763438"
+overlay5_desc4_overlay = "png/clear/button_b.png"
+overlay5_desc4_reach_x = 0
 
-overlay5_desc5 = "y,0.68260038240917786379,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
-overlay5_desc5_overlay = "png/clear/button_y.png"
+overlay5_desc5 = "x,0.78393881453154878880,0.57741935483870965307,radial,0.06118546845124282763,0.03440860215053763438"
+overlay5_desc5_overlay = "png/clear/button_x.png"
+overlay5_desc5_reach_x = 0
+
+overlay5_desc6 = "y,0.68260038240917786379,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
+overlay5_desc6_overlay = "png/clear/button_y.png"
+overlay5_desc6_reach_x = 0
 
 # Select/start
-overlay5_desc6 = "select,0.40057361376673039643,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
-overlay5_desc6_overlay = "png/clear/button_select.png"
+overlay5_desc7 = "select,0.40057361376673039643,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
+overlay5_desc7_overlay = "png/clear/button_select.png"
+overlay5_desc7_reach_x = 1.2
+overlay5_desc7_reach_y = 1.6
+overlay5_desc7_exclusive = true
 
-overlay5_desc7 = "start,0.59942638623326960357,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
-overlay5_desc7_overlay = "png/clear/button_start.png"
+overlay5_desc8 = "start,0.59942638623326960357,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
+overlay5_desc8_overlay = "png/clear/button_start.png"
+overlay5_desc8_reach_x = 1.2
+overlay5_desc8_reach_y = 1.6
+overlay5_desc8_exclusive = true
 
 # L/R buttons
-overlay5_desc8 = "l,0.06883365200764818281,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc8_overlay = "png/clear/button_l1.png"
+overlay5_desc9 = "l,0.06883365200764818281,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc9_overlay = "png/clear/button_l1.png"
+overlay5_desc9_reach_x = 1.2
+overlay5_desc9_reach_y = 2.0
+overlay5_desc9_exclusive = true
 
-overlay5_desc9 = "l2,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc9_overlay = "png/clear/button_l2.png"
+overlay5_desc10 = "l2,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc10_overlay = "png/clear/button_l2.png"
+overlay5_desc10_reach_x = 1.6
+overlay5_desc10_reach_y = 2.0
+overlay5_desc10_exclusive = true
 
-overlay5_desc10 = "l3,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc10_overlay = "png/clear/button_l3.png"
+overlay5_desc11 = "l3,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc11_overlay = "png/clear/button_l3.png"
+overlay5_desc11_reach_x = 1.6
+overlay5_desc11_reach_y = 2.0
+overlay5_desc11_exclusive = true
 
-overlay5_desc11 = "r,0.93116634799235176168,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc11_overlay = "png/clear/button_r1.png"
+overlay5_desc12 = "r,0.93116634799235176168,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc12_overlay = "png/clear/button_r1.png"
+overlay5_desc12_reach_x = 1.2
+overlay5_desc12_reach_y = 2.0
+overlay5_desc12_exclusive = true
 
-overlay5_desc12 = "r2,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc12_overlay = "png/clear/button_r2.png"
+overlay5_desc13 = "r2,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc13_overlay = "png/clear/button_r2.png"
+overlay5_desc13_reach_x = 1.6
+overlay5_desc13_reach_y = 2.0
+overlay5_desc13_exclusive = true
 
-overlay5_desc13 = "r3,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc13_overlay = "png/clear/button_r3.png"
+overlay5_desc14 = "r3,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc14_overlay = "png/clear/button_r3.png"
+overlay5_desc14_reach_x = 1.6
+overlay5_desc14_reach_y = 2.0
+overlay5_desc14_exclusive = true
 
 # Hotkeys
-overlay5_desc14 = "overlay_next,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc14_next_target = "portrait-digital"
-overlay5_desc14_overlay = "png/clear/hotkey_digital.png"
+overlay5_desc15 = "overlay_next,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc15_next_target = "portrait-digital"
+overlay5_desc15_overlay = "png/clear/hotkey_digital.png"
+overlay5_desc15_reach_x = 1.6
+overlay5_desc15_reach_y = 1.6
 
-overlay5_desc15 = "toggle_fast_forward,0.94646271510516255532,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc15_overlay = "png/clear/hotkey_fast_forward.png"
+overlay5_desc16 = "toggle_fast_forward,0.94646271510516255532,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc16_overlay = "png/clear/hotkey_fast_forward.png"
+overlay5_desc16_reach_x = 1.6
+overlay5_desc16_reach_y = 1.6
 
-overlay5_desc16 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc16_next_target = "portrait-hidden-analog"
-overlay5_desc16_overlay = "png/clear/hotkey_hide.png"
+overlay5_desc17 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc17_next_target = "portrait-hidden-analog"
+overlay5_desc17_overlay = "png/clear/hotkey_hide.png"
+overlay5_desc17_reach_x = 1.6
+overlay5_desc17_reach_y = 1.6
 
-overlay5_desc17 = "menu_toggle,0.53824091778202676206,0.56451612903225811824,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc17_overlay = "png/clear/hotkey_menu.png"
+overlay5_desc18 = "menu_toggle,0.53824091778202676206,0.56451612903225811824,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc18_overlay = "png/clear/hotkey_menu.png"
+overlay5_desc18_reach_x = 1.6
+overlay5_desc18_reach_y = 1.6
+overlay5_desc18_exclusive = true
 
 # Invisible rotate hotkey
-overlay5_desc18 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc18_next_target = "landscape-analog"
-#overlay5_desc18_overlay = "png/clear/test_64x64.png"
+overlay5_desc19 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc19_next_target = "landscape-analog"
+#overlay5_desc19_overlay = "png/clear/test_64x64.png"
 
 # Combo buttons
-overlay5_desc19 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
-overlay5_desc20 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
-overlay5_desc21 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
-overlay5_desc22 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
-overlay5_desc23 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
-overlay5_desc24 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
-overlay5_desc25 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
-overlay5_desc26 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+overlay5_desc20 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
+overlay5_desc20_reach_x = 0
+overlay5_desc21 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
+overlay5_desc21_reach_x = 0
+overlay5_desc22 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
+overlay5_desc22_reach_x = 0
+overlay5_desc23 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
+overlay5_desc23_reach_x = 0
+overlay5_desc24 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
+overlay5_desc24_reach_x = 0
+overlay5_desc25 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
+overlay5_desc25_reach_x = 0
+overlay5_desc26 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
+overlay5_desc26_reach_x = 0
+overlay5_desc27 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+overlay5_desc27_reach_x = 0
 
 ## Overlay 6: portrait-hidden-digital
 overlay6_descs = 2
@@ -487,6 +745,8 @@ overlay6_descs = 2
 overlay6_desc0 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
 overlay6_desc0_next_target = "portrait-digital"
 overlay6_desc0_overlay = "png/clear/hotkey_show.png"
+overlay6_desc0_reach_x = 1.6
+overlay6_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
 overlay6_desc1 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
@@ -500,6 +760,8 @@ overlay7_descs = 2
 overlay7_desc0 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
 overlay7_desc0_next_target = "portrait-analog"
 overlay7_desc0_overlay = "png/clear/hotkey_show.png"
+overlay7_desc0_reach_x = 1.6
+overlay7_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
 overlay7_desc1 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"

--- a/gamepads/neo-retropad/neo-retropad.cfg
+++ b/gamepads/neo-retropad/neo-retropad.cfg
@@ -73,195 +73,325 @@ overlay7_range_mod = 1.5
 overlay7_alpha_mod = 2.0
 
 ## Overlay 0: landscape-digital
-overlay0_descs = 37
+overlay0_descs = 39
 
 # D-Pad
-overlay0_desc0 = "down,0.09462365591397849107,0.64340344168260032998,radial,0.03440860215053763438,0.07552581261950286340"
-overlay0_desc0_overlay = "png/default/dpad_down.png"
+overlay0_desc0 = "dpad_area,0.09462365591397849107,0.55640535372848953788,rect,0.089583,0.159259"
+overlay0_desc0_reach_x = 1.9
+overlay0_desc0_reach_y = 1.5
+overlay0_desc0_range_mod = 1.2
+overlay0_desc0_range_mod_exclusive = true
 
-overlay0_desc1 = "left,0.04569892473118279674,0.55640535372848953788,radial,0.04247311827956989222,0.06118546845124282763"
-overlay0_desc1_overlay = "png/default/dpad_left.png"
+overlay0_desc1 = "down,0.09462365591397849107,0.64340344168260032998,rect,0.03440860215053763438,0.07552581261950286340"
+overlay0_desc1_overlay = "png/default/dpad_down.png"
+overlay0_desc1_reach_x = 0
 
-overlay0_desc2 = "right,0.14354838709677419928,0.55640535372848953788,radial,0.04247311827956989222,0.06118546845124282763"
-overlay0_desc2_overlay = "png/default/dpad_right.png"
+overlay0_desc2 = "left,0.04569892473118279674,0.55640535372848953788,rect,0.04247311827956989222,0.06118546845124282763"
+overlay0_desc2_overlay = "png/default/dpad_left.png"
+overlay0_desc2_reach_x = 0
 
-overlay0_desc3 = "up,0.09462365591397849107,0.46940726577437857925,radial,0.03440860215053763438,0.07552581261950286340"
-overlay0_desc3_overlay = "png/default/dpad_up.png"
+overlay0_desc3 = "right,0.14354838709677419928,0.55640535372848953788,rect,0.04247311827956989222,0.06118546845124282763"
+overlay0_desc3_overlay = "png/default/dpad_right.png"
+overlay0_desc3_reach_x = 0
 
-overlay0_desc4 = "down,0.09462365591397849107,0.68116634799235176168,rect,0.03440860215053763438,0.03776290630975143170"
-#overlay0_desc4_overlay = "png/default/test_64x64.png"
+overlay0_desc4 = "up,0.09462365591397849107,0.46940726577437857925,rect,0.03440860215053763438,0.07552581261950286340"
+overlay0_desc4_overlay = "png/default/dpad_up.png"
+overlay0_desc4_reach_x = 0
 
-overlay0_desc5 = "left,0.02446236559139785063,0.55640535372848953788,rect,0.02123655913978494611,0.06118546845124282763"
+overlay0_desc5 = "down,0.09462365591397849107,0.68116634799235176168,rect,0.03440860215053763438,0.03776290630975143170"
 #overlay0_desc5_overlay = "png/default/test_64x64.png"
+overlay0_desc5_reach_x = 0
 
-overlay0_desc6 = "right,0.16478494623655914886,0.55640535372848953788,rect,0.02123655913978494611,0.06118546845124282763"
+overlay0_desc6 = "left,0.02446236559139785063,0.55640535372848953788,rect,0.02123655913978494611,0.06118546845124282763"
 #overlay0_desc6_overlay = "png/default/test_64x64.png"
+overlay0_desc6_reach_x = 0
 
-overlay0_desc7 = "up,0.09462365591397849107,0.43164435946462714755,rect,0.03440860215053763438,0.03776290630975143170"
+overlay0_desc7 = "right,0.16478494623655914886,0.55640535372848953788,rect,0.02123655913978494611,0.06118546845124282763"
 #overlay0_desc7_overlay = "png/default/test_64x64.png"
+overlay0_desc7_reach_x = 0
 
-overlay0_desc8 = "down|left,0.02741935483870967805,0.67590822179732312769,rect,0.02419354838709677352,0.04302103250478011426"
+overlay0_desc8 = "up,0.09462365591397849107,0.43164435946462714755,rect,0.03440860215053763438,0.03776290630975143170"
 #overlay0_desc8_overlay = "png/default/test_64x64.png"
+overlay0_desc8_reach_x = 0
 
-overlay0_desc9 = "down|right,0.16182795698924731798,0.67590822179732312769,rect,0.02419354838709677352,0.04302103250478011426"
+overlay0_desc9 = "down|left,0.02741935483870967805,0.67590822179732312769,rect,0.02419354838709677352,0.04302103250478011426"
 #overlay0_desc9_overlay = "png/default/test_64x64.png"
+overlay0_desc9_reach_x = 0
 
-overlay0_desc10 = "up|left,0.02741935483870967805,0.43690248565965583705,rect,0.02419354838709677352,0.04302103250478011426"
+overlay0_desc10 = "down|right,0.16182795698924731798,0.67590822179732312769,rect,0.02419354838709677352,0.04302103250478011426"
 #overlay0_desc10_overlay = "png/default/test_64x64.png"
+overlay0_desc10_reach_x = 0
 
-overlay0_desc11 = "up|right,0.16182795698924731798,0.43690248565965583705,rect,0.02419354838709677352,0.04302103250478011426"
+overlay0_desc11 = "up|left,0.02741935483870967805,0.43690248565965583705,rect,0.02419354838709677352,0.04302103250478011426"
 #overlay0_desc11_overlay = "png/default/test_64x64.png"
+overlay0_desc11_reach_x = 0
+
+overlay0_desc12 = "up|right,0.16182795698924731798,0.43690248565965583705,rect,0.02419354838709677352,0.04302103250478011426"
+#overlay0_desc12_overlay = "png/default/test_64x64.png"
+overlay0_desc12_reach_x = 0
 
 # ABXY
-overlay0_desc12 = "a,0.96236559139784949579,0.55640535372848953788,radial,0.03440860215053763438,0.06118546845124282763"
-overlay0_desc12_overlay = "png/default/button_a.png"
+overlay0_desc13 = "abxy_area,0.90537634408602152281,0.55640535372848953788,rect,0.089583,0.159259"
+overlay0_desc13_reach_x = 1.4
+overlay0_desc13_reach_y = 1.4
+overlay0_desc13_range_mod = 1.1
+overlay0_desc13_range_mod_exclusive = true
 
-overlay0_desc13 = "b,0.90537634408602152281,0.65774378585086046289,radial,0.03440860215053763438,0.06118546845124282763"
-overlay0_desc13_overlay = "png/default/button_b.png"
+overlay0_desc14 = "a,0.96236559139784949579,0.55640535372848953788,rect,0.03440860215053763438,0.06118546845124282763"
+overlay0_desc14_overlay = "png/default/button_a.png"
+overlay0_desc14_reach_x = 0
 
-overlay0_desc14 = "x,0.90537634408602152281,0.45506692160611855735,radial,0.03440860215053763438,0.06118546845124282763"
-overlay0_desc14_overlay = "png/default/button_x.png"
+overlay0_desc15 = "b,0.90537634408602152281,0.65774378585086046289,rect,0.03440860215053763438,0.06118546845124282763"
+overlay0_desc15_overlay = "png/default/button_b.png"
+overlay0_desc15_reach_x = 0
 
-overlay0_desc15 = "y,0.84838709677419354982,0.55640535372848953788,radial,0.03440860215053763438,0.06118546845124282763"
-overlay0_desc15_overlay = "png/default/button_y.png"
+overlay0_desc16 = "x,0.90537634408602152281,0.45506692160611855735,rect,0.03440860215053763438,0.06118546845124282763"
+overlay0_desc16_overlay = "png/default/button_x.png"
+overlay0_desc16_reach_x = 0
+
+overlay0_desc17 = "y,0.84838709677419354982,0.55640535372848953788,rect,0.03440860215053763438,0.06118546845124282763"
+overlay0_desc17_overlay = "png/default/button_y.png"
+overlay0_desc17_reach_x = 0
 
 # Select/start
-overlay0_desc16 = "select,0.03333333333333333287,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
-overlay0_desc16_overlay = "png/default/button_select.png"
+overlay0_desc18 = "select,0.03333333333333333287,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
+overlay0_desc18_overlay = "png/default/button_select.png"
+overlay0_desc18_reach_x = 1.2
+overlay0_desc18_reach_up = 2.0
+overlay0_desc18_reach_down = 1.6
+overlay0_desc18_exclusive = true
 
-overlay0_desc17 = "start,0.96666666666666667407,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
-overlay0_desc17_overlay = "png/default/button_start.png"
+overlay0_desc19 = "start,0.96666666666666667407,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
+overlay0_desc19_overlay = "png/default/button_start.png"
+overlay0_desc19_reach_x = 1.2
+overlay0_desc19_reach_up = 2.0
+overlay0_desc19_reach_down = 1.6
+overlay0_desc19_exclusive = true
 
 # L/R buttons
-overlay0_desc18 = "l,0.03333333333333333287,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc18_overlay = "png/default/button_l1.png"
+overlay0_desc20 = "l,0.03333333333333333287,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc20_overlay = "png/default/button_l1.png"
+overlay0_desc20_reach_x = 1.2
+overlay0_desc20_reach_down = 1.8
+overlay0_desc20_reach_up = 1.5
+overlay0_desc20_exclusive = true
 
-overlay0_desc19 = "l2,0.03333333333333333287,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc19_overlay = "png/default/button_l2.png"
+overlay0_desc21 = "l2,0.03333333333333333287,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc21_overlay = "png/default/button_l2.png"
+overlay0_desc21_reach_x = 2.0
+overlay0_desc21_reach_y = 1.5
+overlay0_desc21_exclusive = true
 
-overlay0_desc20 = "l3,0.03333333333333333287,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc20_overlay = "png/default/button_l3.png"
+overlay0_desc22 = "l3,0.03333333333333333287,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc22_overlay = "png/default/button_l3.png"
+overlay0_desc22_reach_x = 2.0
+overlay0_desc22_reach_y = 1.5
+overlay0_desc22_exclusive = true
 
-overlay0_desc21 = "r,0.96666666666666667407,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc21_overlay = "png/default/button_r1.png"
+overlay0_desc23 = "r,0.96666666666666667407,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc23_overlay = "png/default/button_r1.png"
+overlay0_desc23_reach_x = 1.2
+overlay0_desc23_reach_down = 1.8
+overlay0_desc23_reach_up = 1.5
+overlay0_desc23_exclusive = true
 
-overlay0_desc22 = "r2,0.96666666666666667407,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc22_overlay = "png/default/button_r2.png"
+overlay0_desc24 = "r2,0.96666666666666667407,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc24_overlay = "png/default/button_r2.png"
+overlay0_desc24_reach_x = 2.0
+overlay0_desc24_reach_y = 1.5
+overlay0_desc24_exclusive = true
 
-overlay0_desc23 = "r3,0.96666666666666667407,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
-overlay0_desc23_overlay = "png/default/button_r3.png"
+overlay0_desc25 = "r3,0.96666666666666667407,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
+overlay0_desc25_overlay = "png/default/button_r3.png"
+overlay0_desc25_reach_x = 2.0
+overlay0_desc25_reach_y = 1.5
+overlay0_desc25_exclusive = true
 
 # Hotkeys
-overlay0_desc24 = "overlay_next,0.02473118279569892428,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc24_next_target = "landscape-analog"
-overlay0_desc24_overlay = "png/default/hotkey_analog.png"
+overlay0_desc26 = "overlay_next,0.02473118279569892428,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc26_next_target = "landscape-analog"
+overlay0_desc26_overlay = "png/default/hotkey_analog.png"
+overlay0_desc26_reach_x = 1.6
+overlay0_desc26_reach_y = 1.6
 
-overlay0_desc25 = "toggle_fast_forward,0.09354838709677419650,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc25_overlay = "png/default/hotkey_fast_forward.png"
+overlay0_desc27 = "toggle_fast_forward,0.09354838709677419650,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc27_overlay = "png/default/hotkey_fast_forward.png"
+overlay0_desc27_reach_x = 1.6
+overlay0_desc27_reach_y = 1.6
 
-overlay0_desc26 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc26_next_target = "landscape-hidden-digital"
-overlay0_desc26_overlay = "png/default/hotkey_hide.png"
+overlay0_desc28 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc28_next_target = "landscape-hidden-digital"
+overlay0_desc28_overlay = "png/default/hotkey_hide.png"
+overlay0_desc28_reach_x = 1.6
+overlay0_desc28_reach_y = 1.6
 
-overlay0_desc27 = "menu_toggle,0.90645161290322584513,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc27_overlay = "png/default/hotkey_menu.png"
+overlay0_desc29 = "menu_toggle,0.90645161290322584513,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc29_overlay = "png/default/hotkey_menu.png"
+overlay0_desc29_reach_x = 1.6
+overlay0_desc29_reach_y = 1.6
 
 # Invisible rotate hotkey
-overlay0_desc28 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
-overlay0_desc28_next_target = "portrait-digital"
-#overlay0_desc28_overlay = "png/default/test_64x64.png"
+overlay0_desc30 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
+overlay0_desc30_next_target = "portrait-digital"
+#overlay0_desc30_overlay = "png/default/test_64x64.png"
 
 # Combo buttons
-overlay0_desc29 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
-overlay0_desc30 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
-overlay0_desc31 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
-overlay0_desc32 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
-overlay0_desc33 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
-overlay0_desc34 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
-overlay0_desc35 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
-overlay0_desc36 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"                                                    
+overlay0_desc31 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
+overlay0_desc31_reach_x = 0
+overlay0_desc32 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
+overlay0_desc32_reach_x = 0
+overlay0_desc33 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
+overlay0_desc33_reach_x = 0
+overlay0_desc34 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
+overlay0_desc34_reach_x = 0
+overlay0_desc35 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
+overlay0_desc35_reach_x = 0
+overlay0_desc36 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
+overlay0_desc36_reach_x = 0
+overlay0_desc37 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
+overlay0_desc37_reach_x = 0
+overlay0_desc38 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
+overlay0_desc38_reach_x = 0
 
 ## Overlay 1: landscape-analog
-overlay1_descs = 27
+overlay1_descs = 20
 
 # Analog stick
-overlay1_desc0 = "nul,0.09462365591397849107,0.55640535372848953788,radial,0.08709677419354838745,0.15487571701720842521"
+overlay1_desc0 = "analog_left,0.09462365591397849107,0.55640535372848953788,radial,0.08709677419354838745,0.15487571701720842521"
 overlay1_desc0_overlay = "png/default/analog_bg.png"
+overlay1_desc0_saturate_pct = 1000000.0
+overlay1_desc0_reach_x = 0
 
 overlay1_desc1 = "analog_left,0.09462365591397849107,0.55640535372848953788,radial,0.05053763440860215006,0.08986615678776291305"
-overlay1_desc1_range_mod = 4.0
-overlay1_desc1_pct = 0.75
-overlay1_desc1_movable = true
 overlay1_desc1_overlay = "png/default/analog_stick.png"
+overlay1_desc1_movable = true
+overlay1_desc1_reach_x = 1.75
+overlay1_desc1_reach_y = 1.75
+overlay1_desc1_range_mod = 4.0
+overlay1_desc1_range_mod_exclusive = true
 
 # ABXY
-overlay1_desc2 = "a,0.96236559139784949579,0.55640535372848953788,radial,0.03440860215053763438,0.06118546845124282763"
-overlay1_desc2_overlay = "png/default/button_a.png"
+overlay1_desc2 = "abxy_area,0.90537634408602152281,0.55640535372848953788,rect,0.089583,0.159259"
+overlay1_desc2_reach_x = 1.4
+overlay1_desc2_reach_y = 1.4
+overlay1_desc2_range_mod = 1.1
+overlay1_desc2_range_mod_exclusive = true
 
-overlay1_desc3 = "b,0.90537634408602152281,0.65774378585086046289,radial,0.03440860215053763438,0.06118546845124282763"
-overlay1_desc3_overlay = "png/default/button_b.png"
+overlay1_desc3 = "a,0.96236559139784949579,0.55640535372848953788,rect,0.03440860215053763438,0.06118546845124282763"
+overlay1_desc3_overlay = "png/default/button_a.png"
+overlay1_desc3_reach_x = 0
 
-overlay1_desc4 = "x,0.90537634408602152281,0.45506692160611855735,radial,0.03440860215053763438,0.06118546845124282763"
-overlay1_desc4_overlay = "png/default/button_x.png"
+overlay1_desc4 = "b,0.90537634408602152281,0.65774378585086046289,rect,0.03440860215053763438,0.06118546845124282763"
+overlay1_desc4_overlay = "png/default/button_b.png"
+overlay1_desc4_reach_x = 0
 
-overlay1_desc5 = "y,0.84838709677419354982,0.55640535372848953788,radial,0.03440860215053763438,0.06118546845124282763"
-overlay1_desc5_overlay = "png/default/button_y.png"
+overlay1_desc5 = "x,0.90537634408602152281,0.45506692160611855735,rect,0.03440860215053763438,0.06118546845124282763"
+overlay1_desc5_overlay = "png/default/button_x.png"
+overlay1_desc5_reach_x = 0
+
+overlay1_desc6 = "y,0.84838709677419354982,0.55640535372848953788,rect,0.03440860215053763438,0.06118546845124282763"
+overlay1_desc6_overlay = "png/default/button_y.png"
+overlay1_desc6_reach_x = 0
 
 # Select/start
-overlay1_desc6 = "select,0.03333333333333333287,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
-overlay1_desc6_overlay = "png/default/button_select.png"
+overlay1_desc7 = "select,0.03333333333333333287,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
+overlay1_desc7_overlay = "png/default/button_select.png"
+overlay1_desc7_reach_x = 1.2
+overlay1_desc7_reach_up = 2.0
+overlay1_desc7_reach_down = 1.6
+overlay1_desc7_exclusive = true
 
-overlay1_desc7 = "start,0.96666666666666667407,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
-overlay1_desc7_overlay = "png/default/button_start.png"
+overlay1_desc8 = "start,0.96666666666666667407,0.81835564053537279694,rect,0.03010752688172043182,0.03824091778202676900"
+overlay1_desc8_overlay = "png/default/button_start.png"
+overlay1_desc8_reach_x = 1.2
+overlay1_desc8_reach_up = 2.0
+overlay1_desc8_reach_down = 1.6
+overlay1_desc8_exclusive = true
 
 # L/R buttons
-overlay1_desc8 = "l,0.03333333333333333287,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc8_overlay = "png/default/button_l1.png"
+overlay1_desc9 = "l,0.03333333333333333287,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc9_overlay = "png/default/button_l1.png"
+overlay1_desc9_reach_x = 1.2
+overlay1_desc9_reach_down = 1.8
+overlay1_desc9_reach_up = 1.5
+overlay1_desc9_exclusive = true
 
-overlay1_desc9 = "l2,0.03333333333333333287,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc9_overlay = "png/default/button_l2.png"
+overlay1_desc10 = "l2,0.03333333333333333287,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc10_overlay = "png/default/button_l2.png"
+overlay1_desc10_reach_x = 2.0
+overlay1_desc10_reach_y = 1.5
+overlay1_desc10_exclusive = true
 
-overlay1_desc10 = "l3,0.03333333333333333287,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc10_overlay = "png/default/button_l3.png"
+overlay1_desc11 = "l3,0.03333333333333333287,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc11_overlay = "png/default/button_l3.png"
+overlay1_desc11_reach_x = 2.0
+overlay1_desc11_reach_y = 1.5
+overlay1_desc11_exclusive = true
 
-overlay1_desc11 = "r,0.96666666666666667407,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc11_overlay = "png/default/button_r1.png"
+overlay1_desc12 = "r,0.96666666666666667407,0.28680688336520077097,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc12_overlay = "png/default/button_r1.png"
+overlay1_desc12_reach_x = 1.2
+overlay1_desc12_reach_down = 1.8
+overlay1_desc12_reach_up = 1.5
+overlay1_desc12_exclusive = true
 
-overlay1_desc12 = "r2,0.96666666666666667407,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc12_overlay = "png/default/button_r2.png"
+overlay1_desc13 = "r2,0.96666666666666667407,0.16921606118546844710,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc13_overlay = "png/default/button_r2.png"
+overlay1_desc13_reach_x = 2.0
+overlay1_desc13_reach_y = 1.5
+overlay1_desc13_exclusive = true
 
-overlay1_desc13 = "r3,0.96666666666666667407,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
-overlay1_desc13_overlay = "png/default/button_r3.png"
+overlay1_desc14 = "r3,0.96666666666666667407,0.05162523900573613711,rect,0.03010752688172043182,0.04588910133843212419"
+overlay1_desc14_overlay = "png/default/button_r3.png"
+overlay1_desc14_reach_x = 2.0
+overlay1_desc14_reach_y = 1.5
+overlay1_desc14_exclusive = true
 
 # Hotkeys
-overlay1_desc14 = "overlay_next,0.02473118279569892428,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc14_next_target = "landscape-digital"
-overlay1_desc14_overlay = "png/default/hotkey_digital.png"
+overlay1_desc15 = "overlay_next,0.02473118279569892428,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc15_next_target = "landscape-digital"
+overlay1_desc15_overlay = "png/default/hotkey_digital.png"
+overlay1_desc15_reach_x = 1.6
+overlay1_desc15_reach_y = 1.6
 
-overlay1_desc15 = "toggle_fast_forward,0.09354838709677419650,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc15_overlay = "png/default/hotkey_fast_forward.png"
+overlay1_desc16 = "toggle_fast_forward,0.09354838709677419650,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc16_overlay = "png/default/hotkey_fast_forward.png"
+overlay1_desc16_reach_x = 1.6
+overlay1_desc16_reach_y = 1.6
 
-overlay1_desc16 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc16_next_target = "landscape-hidden-analog"
-overlay1_desc16_overlay = "png/default/hotkey_hide.png"
+overlay1_desc17 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc17_next_target = "landscape-hidden-analog"
+overlay1_desc17_overlay = "png/default/hotkey_hide.png"
+overlay1_desc17_reach_x = 1.6
+overlay1_desc17_reach_y = 1.6
 
-overlay1_desc17 = "menu_toggle,0.90645161290322584513,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc17_overlay = "png/default/hotkey_menu.png"
+overlay1_desc18 = "menu_toggle,0.90645161290322584513,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc18_overlay = "png/default/hotkey_menu.png"
+overlay1_desc18_reach_x = 1.6
+overlay1_desc18_reach_y = 1.6
 
 # Invisible rotate hotkey
-overlay1_desc18 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
-overlay1_desc18_next_target = "portrait-analog"
-#overlay1_desc18_overlay = "png/default/test_64x64.png"
+overlay1_desc19 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
+overlay1_desc19_next_target = "portrait-analog"
+#overlay1_desc19_overlay = "png/default/test_64x64.png"
 
 # Combo buttons
-overlay1_desc19 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
-overlay1_desc20 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
-overlay1_desc21 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
-overlay1_desc22 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
-overlay1_desc23 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
-overlay1_desc24 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
-overlay1_desc25 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
-overlay1_desc26 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"                                                             
+overlay1_desc20 = "x|y,0.868996,0.492425,radial,0.01389,0.02469"
+overlay1_desc20_reach_x = 0
+overlay1_desc21 = "x|y,0.881496,0.514655,radial,0.01389,0.02469"
+overlay1_desc21_reach_x = 0
+overlay1_desc22 = "a|b,0.931496,0.603535,radial,0.01389,0.02469"
+overlay1_desc22_reach_x = 0
+overlay1_desc23 = "a|b,0.943996,0.625765,radial,0.01389,0.02469"
+overlay1_desc23_reach_x = 0
+overlay1_desc24 = "y|b,0.868996,0.625765,radial,0.01389,0.02469"
+overlay1_desc24_reach_x = 0
+overlay1_desc25 = "y|b,0.881496,0.603535,radial,0.01389,0.02469"
+overlay1_desc25_reach_x = 0
+overlay1_desc26 = "x|a,0.931496,0.514655,radial,0.01389,0.02469"
+overlay1_desc26_reach_x = 0
+overlay1_desc27 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
+overlay1_desc27_reach_x = 0
 
 ## Overlay 2: landscape-hidden-digital
 overlay2_descs = 2
@@ -270,6 +400,8 @@ overlay2_descs = 2
 overlay2_desc0 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
 overlay2_desc0_next_target = "landscape-digital"
 overlay2_desc0_overlay = "png/default/hotkey_show.png"
+overlay2_desc0_reach_x = 1.6
+overlay2_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
 overlay2_desc1 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
@@ -283,6 +415,8 @@ overlay3_descs = 2
 overlay3_desc0 = "overlay_next,0.97526881720430103062,0.95602294455066916257,radial,0.02150537634408602322,0.03824091778202676900"
 overlay3_desc0_next_target = "landscape-analog"
 overlay3_desc0_overlay = "png/default/hotkey_show.png"
+overlay3_desc0_reach_x = 1.6
+overlay3_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
 overlay3_desc1 = "overlay_next,0.50000000000000000000,0.04397705544933078192,radial,0.02150537634408602322,0.03824091778202676900"
@@ -290,195 +424,319 @@ overlay3_desc1_next_target = "portrait-hidden-analog"
 #overlay3_desc1_overlay = "png/default/test_64x64.png"
 
 ## Overlay 4: portrait-digital
-overlay4_descs = 37
+overlay4_descs = 39
 
 # D-Pad
-overlay4_desc0 = "down,0.21606118546845123896,0.68333333333333334814,radial,0.06118546845124282763,0.04247311827956989222"
-overlay4_desc0_overlay = "png/default/dpad_down.png"
+overlay4_desc0 = "dpad_area,0.21606118546845123896,0.63440860215053762605,rect,0.159259,0.089583"
+overlay4_desc0_reach_x = 1.9
+overlay4_desc0_reach_y = 1.5
+overlay4_desc0_range_mod = 1.1
+overlay4_desc0_range_mod_exclusive = true
 
-overlay4_desc1 = "left,0.12906309751434033584,0.63440860215053762605,radial,0.07552581261950286340,0.03440860215053763438"
-overlay4_desc1_overlay = "png/default/dpad_left.png"
+overlay4_desc1 = "down,0.21606118546845123896,0.68333333333333334814,rect,0.06118546845124282763,0.04247311827956989222"
+overlay4_desc1_overlay = "png/default/dpad_down.png"
+overlay4_desc1_reach_x = 0
 
-overlay4_desc2 = "right,0.30305927342256211432,0.63440860215053762605,radial,0.07552581261950286340,0.03440860215053763438"
-overlay4_desc2_overlay = "png/default/dpad_right.png"
+overlay4_desc2 = "left,0.12906309751434033584,0.63440860215053762605,rect,0.07552581261950286340,0.03440860215053763438"
+overlay4_desc2_overlay = "png/default/dpad_left.png"
+overlay4_desc2_reach_x = 0
 
-overlay4_desc3 = "up,0.21606118546845123896,0.58548387096774190397,radial,0.06118546845124282763,0.04247311827956989222"
-overlay4_desc3_overlay = "png/default/dpad_up.png"
+overlay4_desc3 = "right,0.30305927342256211432,0.63440860215053762605,rect,0.07552581261950286340,0.03440860215053763438"
+overlay4_desc3_overlay = "png/default/dpad_right.png"
+overlay4_desc3_reach_x = 0
 
-overlay4_desc4 = "down,0.21606118546845123896,0.70456989247311829772,rect,0.06118546845124282763,0.02123655913978494611"
-#overlay4_desc4_overlay = "png/default/test_64x64.png"
+overlay4_desc4 = "up,0.21606118546845123896,0.58548387096774190397,rect,0.06118546845124282763,0.04247311827956989222"
+overlay4_desc4_overlay = "png/default/dpad_up.png"
+overlay4_desc4_reach_x = 0
 
-overlay4_desc5 = "left,0.09130019120458890414,0.63440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
+overlay4_desc5 = "down,0.21606118546845123896,0.70456989247311829772,rect,0.06118546845124282763,0.02123655913978494611"
 #overlay4_desc5_overlay = "png/default/test_64x64.png"
+overlay4_desc5_reach_x = 0
 
-overlay4_desc6 = "right,0.34082217973231360153,0.63440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
+overlay4_desc6 = "left,0.09130019120458890414,0.63440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
 #overlay4_desc6_overlay = "png/default/test_64x64.png"
+overlay4_desc6_reach_x = 0
 
-overlay4_desc7 = "up,0.21606118546845123896,0.56424731182795695439,rect,0.06118546845124282763,0.02123655913978494611"
+overlay4_desc7 = "right,0.34082217973231360153,0.63440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
 #overlay4_desc7_overlay = "png/default/test_64x64.png"
+overlay4_desc7_reach_x = 0
 
-overlay4_desc8 = "down|left,0.09655831739961759363,0.70161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
+overlay4_desc8 = "up,0.21606118546845123896,0.56424731182795695439,rect,0.06118546845124282763,0.02123655913978494611"
 #overlay4_desc8_overlay = "png/default/test_64x64.png"
+overlay4_desc8_reach_x = 0
 
-overlay4_desc9 = "down|right,0.33556405353728491203,0.70161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
+overlay4_desc9 = "down|left,0.09655831739961759363,0.70161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
 #overlay4_desc9_overlay = "png/default/test_64x64.png"
+overlay4_desc9_reach_x = 0
 
-overlay4_desc10 = "up|left,0.09655831739961759363,0.56720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
+overlay4_desc10 = "down|right,0.33556405353728491203,0.70161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
 #overlay4_desc10_overlay = "png/default/test_64x64.png"
+overlay4_desc10_reach_x = 0
 
-overlay4_desc11 = "up|right,0.33556405353728491203,0.56720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
+overlay4_desc11 = "up|left,0.09655831739961759363,0.56720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
 #overlay4_desc11_overlay = "png/default/test_64x64.png"
+overlay4_desc11_reach_x = 0
+
+overlay4_desc12 = "up|right,0.33556405353728491203,0.56720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
+#overlay4_desc12_overlay = "png/default/test_64x64.png"
+overlay4_desc12_reach_x = 0
 
 # ABXY
-overlay4_desc12 = "a,0.88527724665391971381,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
-overlay4_desc12_overlay = "png/default/button_a.png"
+overlay4_desc13 = "abxy_area,0.78393881453154878880,0.63440860215053762605,rect,0.159259,0.089583"
+overlay4_desc13_reach_x = 1.4
+overlay4_desc13_reach_y = 1.4
+overlay4_desc13_range_mod = 1.1
+overlay4_desc13_range_mod_exclusive = true
 
-overlay4_desc13 = "b,0.78393881453154878880,0.69139784946236559904,radial,0.06118546845124282763,0.03440860215053763438"
-overlay4_desc13_overlay = "png/default/button_b.png"
+overlay4_desc14 = "a,0.88527724665391971381,0.63440860215053762605,rect,0.06118546845124282763,0.03440860215053763438"
+overlay4_desc14_overlay = "png/default/button_a.png"
+overlay4_desc14_reach_x = 0
 
-overlay4_desc14 = "x,0.78393881453154878880,0.57741935483870965307,radial,0.06118546845124282763,0.03440860215053763438"
-overlay4_desc14_overlay = "png/default/button_x.png"
+overlay4_desc15 = "b,0.78393881453154878880,0.69139784946236559904,rect,0.06118546845124282763,0.03440860215053763438"
+overlay4_desc15_overlay = "png/default/button_b.png"
+overlay4_desc15_reach_x = 0
 
-overlay4_desc15 = "y,0.68260038240917786379,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
-overlay4_desc15_overlay = "png/default/button_y.png"
+overlay4_desc16 = "x,0.78393881453154878880,0.57741935483870965307,rect,0.06118546845124282763,0.03440860215053763438"
+overlay4_desc16_overlay = "png/default/button_x.png"
+overlay4_desc16_reach_x = 0
+
+overlay4_desc17 = "y,0.68260038240917786379,0.63440860215053762605,rect,0.06118546845124282763,0.03440860215053763438"
+overlay4_desc17_overlay = "png/default/button_y.png"
+overlay4_desc17_reach_x = 0
 
 # Select/start
-overlay4_desc16 = "select,0.40057361376673039643,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
-overlay4_desc16_overlay = "png/default/button_select.png"
+overlay4_desc18 = "select,0.40057361376673039643,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
+overlay4_desc18_overlay = "png/default/button_select.png"
+overlay4_desc18_reach_x = 1.2
+overlay4_desc18_reach_y = 1.6
+overlay4_desc18_exclusive = true
 
-overlay4_desc17 = "start,0.59942638623326960357,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
-overlay4_desc17_overlay = "png/default/button_start.png"
+overlay4_desc19 = "start,0.59942638623326960357,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
+overlay4_desc19_overlay = "png/default/button_start.png"
+overlay4_desc19_reach_x = 1.2
+overlay4_desc19_reach_y = 1.6
+overlay4_desc19_exclusive = true
 
 # L/R buttons
-overlay4_desc18 = "l,0.06883365200764818281,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc18_overlay = "png/default/button_l1.png"
+overlay4_desc20 = "l,0.06883365200764818281,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc20_overlay = "png/default/button_l1.png"
+overlay4_desc20_reach_x = 1.2
+overlay4_desc20_reach_y = 2.0
+overlay4_desc20_exclusive = true
 
-overlay4_desc19 = "l2,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc19_overlay = "png/default/button_l2.png"
+overlay4_desc21 = "l2,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc21_overlay = "png/default/button_l2.png"
+overlay4_desc21_reach_x = 1.6
+overlay4_desc21_reach_y = 2.0
+overlay4_desc21_exclusive = true
 
-overlay4_desc20 = "l3,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc20_overlay = "png/default/button_l3.png"
+overlay4_desc22 = "l3,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc22_overlay = "png/default/button_l3.png"
+overlay4_desc22_reach_x = 1.6
+overlay4_desc22_reach_y = 2.0
+overlay4_desc22_exclusive = true
 
-overlay4_desc21 = "r,0.93116634799235176168,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc21_overlay = "png/default/button_r1.png"
+overlay4_desc23 = "r,0.93116634799235176168,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc23_overlay = "png/default/button_r1.png"
+overlay4_desc23_reach_x = 1.2
+overlay4_desc23_reach_y = 2.0
+overlay4_desc23_exclusive = true
 
-overlay4_desc22 = "r2,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc22_overlay = "png/default/button_r2.png"
+overlay4_desc24 = "r2,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc24_overlay = "png/default/button_r2.png"
+overlay4_desc24_reach_x = 1.6
+overlay4_desc24_reach_y = 2.0
+overlay4_desc24_exclusive = true
 
-overlay4_desc23 = "r3,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
-overlay4_desc23_overlay = "png/default/button_r3.png"
+overlay4_desc25 = "r3,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay4_desc25_overlay = "png/default/button_r3.png"
+overlay4_desc25_reach_x = 1.6
+overlay4_desc25_reach_y = 2.0
+overlay4_desc25_exclusive = true
 
 # Hotkeys
-overlay4_desc24 = "overlay_next,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc24_next_target = "portrait-analog"
-overlay4_desc24_overlay = "png/default/hotkey_analog.png"
+overlay4_desc26 = "overlay_next,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc26_next_target = "portrait-analog"
+overlay4_desc26_overlay = "png/default/hotkey_analog.png"
+overlay4_desc26_reach_x = 1.6
+overlay4_desc26_reach_y = 1.6
 
-overlay4_desc25 = "toggle_fast_forward,0.94646271510516255532,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc25_overlay = "png/default/hotkey_fast_forward.png"
+overlay4_desc27 = "toggle_fast_forward,0.94646271510516255532,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc27_overlay = "png/default/hotkey_fast_forward.png"
+overlay4_desc27_reach_x = 1.6
+overlay4_desc27_reach_y = 1.6
 
-overlay4_desc26 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc26_next_target = "portrait-hidden-digital"
-overlay4_desc26_overlay = "png/default/hotkey_hide.png"
+overlay4_desc28 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc28_next_target = "portrait-hidden-digital"
+overlay4_desc28_overlay = "png/default/hotkey_hide.png"
+overlay4_desc28_reach_x = 1.6
+overlay4_desc28_reach_y = 1.6
 
-overlay4_desc27 = "menu_toggle,0.53824091778202676206,0.56451612903225811824,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc27_overlay = "png/default/hotkey_menu.png"
+overlay4_desc29 = "menu_toggle,0.53824091778202676206,0.56451612903225811824,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc29_overlay = "png/default/hotkey_menu.png"
+overlay4_desc29_reach_x = 1.6
+overlay4_desc29_reach_y = 1.6
+overlay4_desc29_exclusive = true
 
 # Invisible rotate hotkey
-overlay4_desc28 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
-overlay4_desc28_next_target = "landscape-digital"
-#overlay4_desc28_overlay = "png/default/test_64x64.png"
+overlay4_desc30 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
+overlay4_desc30_next_target = "landscape-digital"
+#overlay4_desc30_overlay = "png/default/test_64x64.png"
 
 # Combo buttons
-overlay4_desc29 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
-overlay4_desc30 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
-overlay4_desc31 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
-overlay4_desc32 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
-overlay4_desc33 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
-overlay4_desc34 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
-overlay4_desc35 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
-overlay4_desc36 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+overlay4_desc31 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
+overlay4_desc31_reach_x = 0
+overlay4_desc32 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
+overlay4_desc32_reach_x = 0
+overlay4_desc33 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
+overlay4_desc33_reach_x = 0
+overlay4_desc34 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
+overlay4_desc34_reach_x = 0
+overlay4_desc35 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
+overlay4_desc35_reach_x = 0
+overlay4_desc36 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
+overlay4_desc36_reach_x = 0
+overlay4_desc37 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
+overlay4_desc37_reach_x = 0
+overlay4_desc38 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+overlay4_desc38_reach_x = 0
 
 ## Overlay 5: portrait-analog
-overlay5_descs = 27
+overlay5_descs = 28
 
 # Analog stick
-overlay5_desc0 = "nul,0.21606118546845123896,0.63440860215053762605,radial,0.15487571701720842521,0.08709677419354838745"
+overlay5_desc0 = "analog_left,0.21606118546845123896,0.63440860215053762605,radial,0.15487571701720842521,0.08709677419354838745"
 overlay5_desc0_overlay = "png/default/analog_bg.png"
+overlay5_desc0_saturate_pct = 1000000.0
+overlay5_desc0_reach_x = 0
 
 overlay5_desc1 = "analog_left,0.21606118546845123896,0.63440860215053762605,radial,0.08986615678776291305,0.05053763440860215006"
-overlay5_desc1_range_mod = 4.0
-overlay5_desc1_pct = 0.75
-overlay5_desc1_movable = true
 overlay5_desc1_overlay = "png/default/analog_stick.png"
+overlay5_desc1_movable = true
+overlay5_desc1_reach_x = 1.3
+overlay5_desc1_reach_y = 1.3
+overlay5_desc1_range_mod = 3.0
+overlay5_desc1_range_mod_exclusive = true
 
 # ABXY
-overlay5_desc2 = "a,0.88527724665391971381,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
-overlay5_desc2_overlay = "png/default/button_a.png"
+overlay5_desc2 = "abxy_area,0.78393881453154878880,0.63440860215053762605,rect,0.159259,0.089583"
+overlay5_desc2_reach_x = 1.4
+overlay5_desc2_reach_y = 1.4
+overlay5_desc2_range_mod = 1.1
+overlay5_desc2_range_mod_exclusive = true
 
-overlay5_desc3 = "b,0.78393881453154878880,0.69139784946236559904,radial,0.06118546845124282763,0.03440860215053763438"
-overlay5_desc3_overlay = "png/default/button_b.png"
+overlay5_desc3 = "a,0.88527724665391971381,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
+overlay5_desc3_overlay = "png/default/button_a.png"
+overlay5_desc3_reach_x = 0
 
-overlay5_desc4 = "x,0.78393881453154878880,0.57741935483870965307,radial,0.06118546845124282763,0.03440860215053763438"
-overlay5_desc4_overlay = "png/default/button_x.png"
+overlay5_desc4 = "b,0.78393881453154878880,0.69139784946236559904,radial,0.06118546845124282763,0.03440860215053763438"
+overlay5_desc4_overlay = "png/default/button_b.png"
+overlay5_desc4_reach_x = 0
 
-overlay5_desc5 = "y,0.68260038240917786379,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
-overlay5_desc5_overlay = "png/default/button_y.png"
+overlay5_desc5 = "x,0.78393881453154878880,0.57741935483870965307,radial,0.06118546845124282763,0.03440860215053763438"
+overlay5_desc5_overlay = "png/default/button_x.png"
+overlay5_desc5_reach_x = 0
+
+overlay5_desc6 = "y,0.68260038240917786379,0.63440860215053762605,radial,0.06118546845124282763,0.03440860215053763438"
+overlay5_desc6_overlay = "png/default/button_y.png"
+overlay5_desc6_reach_x = 0
 
 # Select/start
-overlay5_desc6 = "select,0.40057361376673039643,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
-overlay5_desc6_overlay = "png/default/button_select.png"
+overlay5_desc7 = "select,0.40057361376673039643,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
+overlay5_desc7_overlay = "png/default/button_select.png"
+overlay5_desc7_reach_x = 1.2
+overlay5_desc7_reach_y = 1.6
+overlay5_desc7_exclusive = true
 
-overlay5_desc7 = "start,0.59942638623326960357,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
-overlay5_desc7_overlay = "png/default/button_start.png"
+overlay5_desc8 = "start,0.59942638623326960357,0.78172043010752689796,rect,0.05353728489483747938,0.02150537634408602322"
+overlay5_desc8_overlay = "png/default/button_start.png"
+overlay5_desc8_reach_x = 1.2
+overlay5_desc8_reach_y = 1.6
+overlay5_desc8_exclusive = true
 
 # L/R buttons
-overlay5_desc8 = "l,0.06883365200764818281,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc8_overlay = "png/default/button_l1.png"
+overlay5_desc9 = "l,0.06883365200764818281,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc9_overlay = "png/default/button_l1.png"
+overlay5_desc9_reach_x = 1.2
+overlay5_desc9_reach_y = 2.0
+overlay5_desc9_exclusive = true
 
-overlay5_desc9 = "l2,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc9_overlay = "png/default/button_l2.png"
+overlay5_desc10 = "l2,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc10_overlay = "png/default/button_l2.png"
+overlay5_desc10_reach_x = 1.6
+overlay5_desc10_reach_y = 2.0
+overlay5_desc10_exclusive = true
 
-overlay5_desc10 = "l3,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc10_overlay = "png/default/button_l3.png"
+overlay5_desc11 = "l3,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc11_overlay = "png/default/button_l3.png"
+overlay5_desc11_reach_x = 1.6
+overlay5_desc11_reach_y = 2.0
+overlay5_desc11_exclusive = true
 
-overlay5_desc11 = "r,0.93116634799235176168,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc11_overlay = "png/default/button_r1.png"
+overlay5_desc12 = "r,0.93116634799235176168,0.78602150537634407623,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc12_overlay = "png/default/button_r1.png"
+overlay5_desc12_reach_x = 1.2
+overlay5_desc12_reach_y = 2.0
+overlay5_desc12_exclusive = true
 
-overlay5_desc12 = "r2,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc12_overlay = "png/default/button_r2.png"
+overlay5_desc13 = "r2,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc13_overlay = "png/default/button_r2.png"
+overlay5_desc13_reach_x = 1.6
+overlay5_desc13_reach_y = 2.0
+overlay5_desc13_exclusive = true
 
-overlay5_desc13 = "r3,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
-overlay5_desc13_overlay = "png/default/button_r3.png"
+overlay5_desc14 = "r3,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay5_desc14_overlay = "png/default/button_r3.png"
+overlay5_desc14_reach_x = 1.6
+overlay5_desc14_reach_y = 2.0
+overlay5_desc14_exclusive = true
 
 # Hotkeys
-overlay5_desc14 = "overlay_next,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc14_next_target = "portrait-digital"
-overlay5_desc14_overlay = "png/default/hotkey_digital.png"
+overlay5_desc15 = "overlay_next,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc15_next_target = "portrait-digital"
+overlay5_desc15_overlay = "png/default/hotkey_digital.png"
+overlay5_desc15_reach_x = 1.6
+overlay5_desc15_reach_y = 1.6
 
-overlay5_desc15 = "toggle_fast_forward,0.94646271510516255532,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc15_overlay = "png/default/hotkey_fast_forward.png"
+overlay5_desc16 = "toggle_fast_forward,0.94646271510516255532,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc16_overlay = "png/default/hotkey_fast_forward.png"
+overlay5_desc16_reach_x = 1.6
+overlay5_desc16_reach_y = 1.6
 
-overlay5_desc16 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc16_next_target = "portrait-hidden-analog"
-overlay5_desc16_overlay = "png/default/hotkey_hide.png"
+overlay5_desc17 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc17_next_target = "portrait-hidden-analog"
+overlay5_desc17_overlay = "png/default/hotkey_hide.png"
+overlay5_desc17_reach_x = 1.6
+overlay5_desc17_reach_y = 1.6
 
-overlay5_desc17 = "menu_toggle,0.53824091778202676206,0.56451612903225811824,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc17_overlay = "png/default/hotkey_menu.png"
+overlay5_desc18 = "menu_toggle,0.53824091778202676206,0.56451612903225811824,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc18_overlay = "png/default/hotkey_menu.png"
+overlay5_desc18_reach_x = 1.6
+overlay5_desc18_reach_y = 1.6
+overlay5_desc18_exclusive = true
 
 # Invisible rotate hotkey
-overlay5_desc18 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
-overlay5_desc18_next_target = "landscape-analog"
-#overlay5_desc18_overlay = "png/default/test_64x64.png"
+overlay5_desc19 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
+overlay5_desc19_next_target = "landscape-analog"
+#overlay5_desc19_overlay = "png/default/test_64x64.png"
 
 # Combo buttons
-overlay5_desc19 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
-overlay5_desc20 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
-overlay5_desc21 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
-overlay5_desc22 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
-overlay5_desc23 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
-overlay5_desc24 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
-overlay5_desc25 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
-overlay5_desc26 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+overlay5_desc20 = "x|y,0.719336,0.596733,radial,0.02469,0.01389"
+overlay5_desc20_reach_x = 0
+overlay5_desc21 = "x|y,0.744591,0.614428,radial,0.02469,0.01389"
+overlay5_desc21_reach_x = 0
+overlay5_desc22 = "a|b,0.826904,0.657957,radial,0.02469,0.01389"
+overlay5_desc22_reach_x = 0
+overlay5_desc23 = "a|b,0.847057,0.675652,radial,0.02469,0.01389"
+overlay5_desc23_reach_x = 0
+overlay5_desc24 = "y|b,0.722737,0.671116,radial,0.02469,0.01389"
+overlay5_desc24_reach_x = 0
+overlay5_desc25 = "y|b,0.742891,0.657957,radial,0.02469,0.01389"
+overlay5_desc25_reach_x = 0
+overlay5_desc26 = "x|a,0.828605,0.611027,radial,0.02469,0.01389"
+overlay5_desc26_reach_x = 0
+overlay5_desc27 = "x|a,0.847908,0.596733,radial,0.02469,0.01389"
+overlay5_desc27_reach_x = 0
 
 ## Overlay 6: portrait-hidden-digital
 overlay6_descs = 2
@@ -487,6 +745,8 @@ overlay6_descs = 2
 overlay6_desc0 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
 overlay6_desc0_next_target = "portrait-digital"
 overlay6_desc0_overlay = "png/default/hotkey_show.png"
+overlay6_desc0_reach_x = 1.6
+overlay6_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
 overlay6_desc1 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
@@ -500,6 +760,8 @@ overlay7_descs = 2
 overlay7_desc0 = "overlay_next,0.94646271510516255532,0.96989247311827953002,radial,0.03824091778202676900,0.02150537634408602322"
 overlay7_desc0_next_target = "portrait-analog"
 overlay7_desc0_overlay = "png/default/hotkey_show.png"
+overlay7_desc0_reach_x = 1.6
+overlay7_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
 overlay7_desc1 = "overlay_next,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"


### PR DESCRIPTION
- Eightway areas used for D-Pad and ABXY
- Hitboxes enlarged

For compatibility, unused descriptors are kept - hitboxes zeroed via 'reach'

Edit: Updated based on libretro/RetroArch#14619 to shrink/simplify the cfg files a bit