### PR TITLE
neo-retropad: Fix descriptor count in landscape-analog

### DIFF
--- a/gamepads/neo-retropad/neo-retropad-clear.cfg
+++ b/gamepads/neo-retropad/neo-retropad-clear.cfg
@@ -254,7 +254,7 @@ overlay0_desc38 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
 overlay0_desc38_reach_x = 0
 
 ## Overlay 1: landscape-analog
-overlay1_descs = 20
+overlay1_descs = 28
 
 # Analog stick
 overlay1_desc0 = "analog_left,0.09462365591397849107,0.55640535372848953788,radial,0.08709677419354838745,0.15487571701720842521"

--- a/gamepads/neo-retropad/neo-retropad.cfg
+++ b/gamepads/neo-retropad/neo-retropad.cfg
@@ -254,7 +254,7 @@ overlay0_desc38 = "x|a,0.943996,0.492425,radial,0.01389,0.02469"
 overlay0_desc38_reach_x = 0
 
 ## Overlay 1: landscape-analog
-overlay1_descs = 20
+overlay1_descs = 28
 
 # Analog stick
 overlay1_desc0 = "analog_left,0.09462365591397849107,0.55640535372848953788,radial,0.08709677419354838745,0.15487571701720842521"


### PR DESCRIPTION
This fixes a mistake I made in the previous PR and didn't catch in testing.

Affects diagonals on older versions of RetroArch.