### PR TITLE
Keyboards: Add 'nul' areas to block touchscreen mouse

### DIFF
--- a/keyboards/US-101/US-101.cfg
+++ b/keyboards/US-101/US-101.cfg
@@ -2,7 +2,7 @@ overlays = 6
 overlay0_name = landscape-qwerty
 overlay0_normalized = true
 overlay0_full_screen = true
-overlay0_descs = 105
+overlay0_descs = 106
 
 overlay0_overlay = landscape-qwerty.png
 overlay1_name = landscape-hide
@@ -15,7 +15,7 @@ overlay2_name = portrait-qwerty
 overlay2_normalized = true
 overlay2_overlay = portrait-qwerty.png
 overlay2_full_screen = true
-overlay2_descs = 76
+overlay2_descs = 77
 
 overlay3_name = portrait-qwerty-hide
 overlay3_normalized = true
@@ -27,7 +27,7 @@ overlay4_name = portrait-kp
 overlay4_normalized = true
 overlay4_overlay = portrait-kp.png
 overlay4_full_screen = true
-overlay4_descs = 35
+overlay4_descs = 36
 
 overlay5_name = portrait-kp-hide
 overlay5_overlay = portrait-kp-hide.png
@@ -142,6 +142,8 @@ overlay0_desc102_next_target = portrait-qwerty
 overlay0_desc103 = "overlay_next,0.5,0.4360,radial,0.0500,0.0450"
 overlay0_desc103_next_target = landscape-hide
 overlay0_desc104 = "osk_toggle,0.9290,0.5390,rect,0.0240,0.042"
+# nul area to block mouse
+overlay0_desc105 = "nul,0.5,0.74731,rect,0.5,0.25048"
 
 overlay1_desc0 = "overlay_next,0.5,0.9600,radial,0.0500,0.0450"
 overlay1_desc0_next_target = landscape-qwerty
@@ -225,6 +227,8 @@ overlay2_desc72 = "retrok_ralt,0.7911,0.9708,rect,0.0490,0.033"
 overlay2_desc73 = "retrok_rctrl,0.9535,0.9708,rect,0.044,0.033"
 overlay2_desc74 = "menu_toggle,0.1680,0.5855,rect,0.036,0.033"
 overlay2_desc75 = "osk_toggle,0.9618,0.5855,rect,0.036,0.033"
+# nul area to block mouse
+overlay2_desc76 = "nul,0.5,0.81032,rect,0.5,0.19111"
 
 overlay3_desc0 = "overlay_next,0.5,0.9600,rect,0.0735,0.0400"
 overlay3_desc0_next_target = portrait-qwerty
@@ -267,6 +271,8 @@ overlay4_desc32_next_target = portrait-qwerty
 overlay4_desc33 = "overlay_next,0.5,0.5335,radial,0.0735,0.0400"
 overlay4_desc33_next_target = portrait-kp-hide
 overlay4_desc34 = "osk_toggle,0.6308,0.6548,rect,0.036,0.033"
+# nul area to block mouse
+overlay4_desc35 = "nul,0.52979,0.81032,rect,0.33065,0.18602"
 
 overlay5_desc0 = "overlay_next,0.5,0.9600,rect,0.0735,0.0400"
 overlay5_desc0_next_target = portrait-kp

--- a/keyboards/commodore/plus4.cfg
+++ b/keyboards/commodore/plus4.cfg
@@ -2,7 +2,7 @@ overlays = 3
 
 overlay0_normalized = true
 overlay0_full_screen = true
-overlay0_descs = 73
+overlay0_descs = 74
 overlay0_alpha_mod = 2.0
 overlay0_block_x_separation = true
 overlay0_name = "keyboard"
@@ -167,6 +167,8 @@ overlay0_desc71_overlay = joystick.png
 overlay0_desc71_next_target = "joystick"
 overlay0_desc72 = "osk_toggle,0.0361,0.11,rect,0.03125,0.0625"
 overlay0_desc72_overlay = osk-toggle.png
+# nul area to block mouse
+overlay0_desc73 = "nul,0.5,0.52442,rect,0.5,0.31663"
 
 overlay1_desc0 = "left,0.04375,0.80208333333,radial,0.0525,0.0875"
 overlay1_desc1 = "right,0.19375,0.80208333333,radial,0.0525,0.0875"

--- a/keyboards/modular-keyboard/clear/big.cfg
+++ b/keyboards/modular-keyboard/clear/big.cfg
@@ -12,7 +12,7 @@ overlay0_name = "tenkeyless_landscape"
 
 overlay1_normalized = true
 overlay1_full_screen = true
-overlay1_descs = 35
+overlay1_descs = 36
 overlay1_alpha_mod = 2.0
 overlay1_block_x_separation = true
 overlay1_name = "keypad_landscape"
@@ -40,7 +40,7 @@ overlay4_name = "tenkeyless_portrait"
 
 overlay5_normalized = true
 overlay5_full_screen = true
-overlay5_descs = 35
+overlay5_descs = 36
 overlay5_alpha_mod = 2.0
 overlay5_block_x_separation = true
 overlay5_name = "keypad_portrait"
@@ -90,8 +90,8 @@ overlay0_desc13_overlay = numpad.png
 overlay0_desc13_next_target = "keypad_landscape"
 overlay0_desc14 = "osk_toggle,0.8925,0.16,rect,0.03125,0.0625"
 overlay0_desc14_overlay = osk-toggle.png
-overlay0_desc15 = "nul,0.787037,0.29,rect,0.03125,0.0625"
-#overlay0_desc15_overlay = pause.png
+# nul area to block mouse
+overlay0_desc15 = "nul,0.5,0.613,rect,0.5,0.38709"
 overlay0_desc16 = "retrok_tilde,0.03125,0.42,rect,0.03125,0.0625"
 overlay0_desc16_overlay = tilde.png
 overlay0_desc17 = "retrok_num1,0.1071,0.42,rect,0.03125,0.0625"
@@ -290,6 +290,8 @@ overlay1_desc33_next_target = "hidden_keypad_landscape"
 overlay1_desc34 = "overlay_next,0.03125,0.16,rect,0.03125,0.0625"
 overlay1_desc34_overlay = orientation.png
 overlay1_desc34_next_target = "keypad_portrait"
+# nul area to block mouse
+overlay1_desc35 = "nul,0.5,0.67757,rect,0.2814,0.32166"
 
 overlay2_desc0 = "overlay_next,0.5,0.924375,rect,0.03125,0.0625"
 overlay2_desc0_overlay = show.png
@@ -330,8 +332,8 @@ overlay4_desc13_overlay = numpad.png
 overlay4_desc13_next_target = "keypad_portrait"
 overlay4_desc14 = "osk_toggle,0.8925,0.752,rect,0.0357,0.015625"
 overlay4_desc14_overlay = osk-toggle.png
-overlay4_desc15 = "nul,0.787037,0.784722,rect,0.0357,0.015625"
-#overlay4_desc15_overlay = pause.png
+# nul area to block mouse
+overlay4_desc15 = "nul,0.5,0.885,rect,0.5,0.11625"
 overlay4_desc16 = "retrok_tilde,0.0357,0.852431,rect,0.0357,0.015625"
 overlay4_desc16_overlay = tilde.png
 overlay4_desc17 = "retrok_num1,0.1071,0.852431,rect,0.0357,0.015625"
@@ -530,6 +532,8 @@ overlay5_desc33_next_target = "hidden_keypad_portrait"
 overlay5_desc34 = "overlay_next,0.0357,0.752,rect,0.0357,0.015625"
 overlay5_desc34_overlay = orientation.png
 overlay5_desc34_next_target = "keypad_landscape"
+# nul area to block mouse
+overlay5_desc35 = "nul,0.5,0.91861,rect,0.28341,0.08064"
 
 overlay6_desc0 = "overlay_next,0.5,0.984375,rect,0.0357,0.015625"
 overlay6_desc0_overlay = show.png

--- a/keyboards/modular-keyboard/clear/small.cfg
+++ b/keyboards/modular-keyboard/clear/small.cfg
@@ -2,14 +2,14 @@ overlays = 4
 
 overlay0_normalized = true
 overlay0_full_screen = true
-overlay0_descs = 105
+overlay0_descs = 106
 overlay0_alpha_mod = 2.0
 overlay0_block_x_separation = true
 overlay0_name = "qwerty_landscape"
 
 overlay1_normalized = true
 overlay1_full_screen = true
-overlay1_descs = 105
+overlay1_descs = 106
 overlay1_alpha_mod = 2.0
 overlay1_block_x_separation = true
 overlay1_name = "qwerty_portrait"
@@ -241,6 +241,8 @@ overlay0_desc103_reach_x = 0
 overlay0_desc104 = "overlay_next,0.5,0.487166,rect,0.020833,0.0375"
 overlay0_desc104_overlay = hide.png
 overlay0_desc104_next_target = "hidden_landscape"
+# nul area to block mouse
+overlay0_desc105 = "nul,0.5,0.76457,rect,0.5,0.23754"
 
 overlay1_desc0 = "retrok_escape,0.020833,0.784722,rect,0.020833,0.015625"
 overlay1_desc0_overlay = esc.png
@@ -455,6 +457,8 @@ overlay1_desc103_reach_x = 0
 overlay1_desc104 = "overlay_next,0.5,0.751736,rect,0.020833,0.015625"
 overlay1_desc104_overlay = hide.png
 overlay1_desc104_next_target = "hidden_portrait"
+# nul area to block mouse
+overlay1_desc105 = "nul,0.5,0.88518,rect,0.5,0.115"
 
 overlay2_desc0 = "overlay_next,0.5,0.962500,rect,0.020833,0.0375"
 overlay2_desc0_overlay = show.png

--- a/keyboards/modular-keyboard/opaque/big.cfg
+++ b/keyboards/modular-keyboard/opaque/big.cfg
@@ -12,7 +12,7 @@ overlay0_name = "tenkeyless_landscape"
 
 overlay1_normalized = true
 overlay1_full_screen = true
-overlay1_descs = 35
+overlay1_descs = 36
 overlay1_alpha_mod = 2.0
 overlay1_block_x_separation = true
 overlay1_name = "keypad_landscape"
@@ -40,7 +40,7 @@ overlay4_name = "tenkeyless_portrait"
 
 overlay5_normalized = true
 overlay5_full_screen = true
-overlay5_descs = 35
+overlay5_descs = 36
 overlay5_alpha_mod = 2.0
 overlay5_block_x_separation = true
 overlay5_name = "keypad_portrait"
@@ -106,8 +106,8 @@ overlay0_desc13_overlay = numpad.png
 overlay0_desc13_next_target = "keypad_landscape"
 overlay0_desc14 = osk_toggle,0.8925,0.16,rect,0.03125,0.0625"
 overlay0_desc14_overlay = osk-toggle.png
-overlay0_desc15 = "nul,0.787037,0.29,rect,0.03125,0.0625"
-#overlay0_desc15_overlay = pause.png
+# nul area to block mouse
+overlay0_desc15 = "nul,0.5,0.613,rect,0.5,0.38709"
 overlay0_desc16 = "retrok_tilde,0.03125,0.42,rect,0.03125,0.0625"
 overlay0_desc16_overlay = tilde.png
 overlay0_desc17 = "retrok_num1,0.1071,0.42,rect,0.03125,0.0625"
@@ -240,7 +240,7 @@ overlay1_desc1 = "retrok_scroll_lock,0.3213,0.42,rect,0.03125,0.0625"
 overlay1_desc1_overlay = scr-lk.png
 overlay1_desc2 = "retrok_pause,0.3927,0.42,rect,0.03125,0.0625"
 overlay1_desc2_overlay = pause.png
-overlay1_desc3 ="osk_toggle,0.8925,0.16,rect,0.03125,0.0625"
+overlay1_desc3 = "osk_toggle,0.8925,0.16,rect,0.03125,0.0625"
 overlay1_desc3_overlay = osk-toggle.png
 overlay1_desc4 = "retrok_numlock,0.5355,0.42,rect,0.03125,0.0625"
 overlay1_desc4_overlay = num-lock.png
@@ -307,6 +307,8 @@ overlay1_desc33_next_target = "hidden_keypad_landscape"
 overlay1_desc34 = "overlay_next,0.03125,0.16,rect,0.03125,0.0625"
 overlay1_desc34_overlay = orientation.png
 overlay1_desc34_next_target = "keypad_portrait"
+# nul area to block mouse
+overlay1_desc35 = "nul,0.5,0.67757,rect,0.2814,0.32166"
 
 overlay2_desc0 = "overlay_next,0.5,0.924375,rect,0.03125,0.0625"
 overlay2_desc0_overlay = show.png
@@ -347,8 +349,8 @@ overlay4_desc13_overlay = numpad.png
 overlay4_desc13_next_target = "keypad_portrait"
 overlay4_desc14 = "osk_toggle,0.8925,0.752,rect,0.0357,0.015625"
 overlay4_desc14_overlay = osk-toggle.png
-overlay4_desc15 = "nul,0.787037,0.784722,rect,0.0357,0.015625"
-#overlay4_desc15_overlay = pause.png
+# nul area to block mouse
+overlay4_desc15 = "nul,0.5,0.885,rect,0.5,0.11625"
 overlay4_desc16 = "retrok_tilde,0.0357,0.852431,rect,0.0357,0.015625"
 overlay4_desc16_overlay = tilde.png
 overlay4_desc17 = "retrok_num1,0.1071,0.852431,rect,0.0357,0.015625"
@@ -548,6 +550,8 @@ overlay5_desc33_next_target = "hidden_keypad_portrait"
 overlay5_desc34 = "overlay_next,0.0357,0.752,rect,0.0357,0.015625"
 overlay5_desc34_overlay = orientation.png
 overlay5_desc34_next_target = "keypad_landscape"
+# nul area to block mouse
+overlay5_desc35 = "nul,0.5,0.91861,rect,0.28341,0.08064"
 
 overlay6_desc0 = "overlay_next,0.5,0.984375,rect,0.0357,0.015625"
 overlay6_desc0_overlay = show.png
@@ -588,8 +592,8 @@ overlay8_desc13_overlay = numpad.png
 overlay8_desc13_next_target = "keypad_landscape"
 overlay8_desc14 = "osk_toggle,0.8925,0.16,rect,0.03125,0.0625"
 overlay8_desc14_overlay = osk-toggle.png
-overlay8_desc15 = "nul,0.787037,0.29,rect,0.03125,0.0625"
-#overlay8_desc15_overlay = pause.png
+# nul area to block mouse
+overlay8_desc15 = "nul,0.5,0.613,rect,0.5,0.38709"
 overlay8_desc16 = "retrok_tilde,0.03125,0.42,rect,0.03125,0.0625"
 overlay8_desc16_overlay = shift-tilde.png
 overlay8_desc17 = "retrok_num1,0.1071,0.42,rect,0.03125,0.0625"
@@ -755,8 +759,8 @@ overlay9_desc13_overlay = numpad.png
 overlay9_desc13_next_target = "keypad_portrait"
 overlay9_desc14 = "osk_toggle,0.8925,0.752,rect,0.0357,0.015625"
 overlay9_desc14_overlay = osk-toggle.png
-overlay9_desc15 = "nul,0.787037,0.784722,rect,0.0357,0.015625"
-#overlay9_desc15_overlay = pause.png
+# nul area to block mouse
+overlay9_desc15 = "nul,0.5,0.885,rect,0.5,0.11625"
 overlay9_desc16 = "retrok_tilde,0.0357,0.852431,rect,0.0357,0.015625"
 overlay9_desc16_overlay = shift-tilde.png
 overlay9_desc17 = "retrok_num1,0.1071,0.852431,rect,0.0357,0.015625"

--- a/keyboards/modular-keyboard/opaque/small.cfg
+++ b/keyboards/modular-keyboard/opaque/small.cfg
@@ -2,28 +2,28 @@ overlays = 6
 
 overlay0_normalized = true
 overlay0_full_screen = true
-overlay0_descs = 105
+overlay0_descs = 106
 overlay0_alpha_mod = 2.0
 overlay0_block_x_separation = true
 overlay0_name = "qwerty_landscape"
 
 overlay1_normalized = true
 overlay1_full_screen = true
-overlay1_descs = 109
+overlay1_descs = 110
 overlay1_alpha_mod = 2.0
 overlay1_block_x_separation = true
 overlay1_name = "shift_landscape"
 
 overlay2_normalized = true
 overlay2_full_screen = true
-overlay2_descs = 105
+overlay2_descs = 106
 overlay2_alpha_mod = 2.0
 overlay2_block_x_separation = true
 overlay2_name = "qwerty_portrait"
 
 overlay3_normalized = true
 overlay3_full_screen = true
-overlay3_descs = 109
+overlay3_descs = 110
 overlay3_alpha_mod = 2.0
 overlay3_block_x_separation = true
 overlay3_name = "shift_portrait"
@@ -256,6 +256,8 @@ overlay0_desc103_reach_x = 0
 overlay0_desc104 = "overlay_next,0.5,0.487166,rect,0.020833,0.0375"
 overlay0_desc104_overlay = hide.png
 overlay0_desc104_next_target = "hidden_landscape"
+# nul area to block mouse
+overlay0_desc105 = "nul,0.5,0.76457,rect,0.5,0.23754"
 
 overlay1_desc0 = "retrok_escape,0.020833,0.5665,rect,0.020833,0.0375"
 overlay1_desc0_overlay = esc.png
@@ -479,6 +481,8 @@ overlay1_desc107_reach_x = 0
 overlay1_desc108 = "overlay_next,0.5,0.487166,rect,0.020833,0.0375"
 overlay1_desc108_overlay = hide.png
 overlay1_desc108_next_target = "hidden_landscape"
+# nul area to block mouse
+overlay1_desc109 = "nul,0.5,0.76457,rect,0.5,0.23754"
 
 overlay2_desc0 = "retrok_escape,0.020833,0.784722,rect,0.020833,0.015625"
 overlay2_desc0_overlay = esc.png
@@ -694,6 +698,8 @@ overlay2_desc103_reach_x = 0
 overlay2_desc104 = "overlay_next,0.5,0.751736,rect,0.020833,0.015625"
 overlay2_desc104_overlay = hide.png
 overlay2_desc104_next_target = "hidden_portrait"
+# nul area to block mouse
+overlay2_desc105 = "nul,0.5,0.88518,rect,0.5,0.115"
 
 overlay3_desc0 = "retrok_escape,0.020833,0.784722,rect,0.020833,0.015625"
 overlay3_desc0_overlay = esc.png
@@ -917,6 +923,8 @@ overlay3_desc107 = "retrok_shift,0.28477,0.852431,rect,0.28477,0.015625"
 overlay3_desc108 = "overlay_next,0.5,0.751736,rect,0.020833,0.015625"
 overlay3_desc108_overlay = hide.png
 overlay3_desc108_next_target = "hidden_portrait"
+# nul area to block mouse
+overlay3_desc109 = "nul,0.5,0.88518,rect,0.5,0.115"
 
 overlay4_desc0 = "overlay_next,0.5,0.962500,rect,0.020833,0.0375"
 overlay4_desc0_overlay = show.png

--- a/keyboards/qwerty-big/qwerty-big.cfg
+++ b/keyboards/qwerty-big/qwerty-big.cfg
@@ -2,7 +2,7 @@ overlays = 1
 overlay0_name = portrait-qwerty
 overlay0_normalized = true
 overlay0_full_screen = true
-overlay0_descs = 103
+overlay0_descs = 104
 overlay0_overlay = qwerty-big.png
 
 overlay0_desc0 = "retrok_escape,0.020833,0.784722,rect,0.020833,0.015625"
@@ -108,3 +108,5 @@ overlay0_desc99 = "retrok_keypad0,0.869213,0.984375,rect,0.042824,0.015625"
 overlay0_desc100 = "retrok_kp_period,0.935185,0.984375,rect,0.020833,0.015625"
 overlay0_desc101 = "menu_toggle,0.979167,0.784722,rect,0.020833,0.015625"
 overlay0_desc102 = "osk_toggle,0.935185,0.784722,rect,0.020833,0.015625"
+# nul area to block mouse
+overlay0_desc103 = "nul,0.5,0.8835,rect,0.5,0.1148"

--- a/keyboards/qwerty/qwerty.cfg
+++ b/keyboards/qwerty/qwerty.cfg
@@ -2,7 +2,7 @@ overlays = 1
 overlay0_name = portrait-qwerty
 overlay0_normalized = true
 overlay0_full_screen = true
-overlay0_descs = 103
+overlay0_descs = 104
 overlay0_overlay = qwerty.png
 
 overlay0_desc0 = "retrok_escape,0.020833,0.784722,rect,0.020833,0.015625"
@@ -108,3 +108,5 @@ overlay0_desc99 = "retrok_keypad0,0.869213,0.984375,rect,0.042824,0.015625"
 overlay0_desc100 = "retrok_kp_period,0.935185,0.984375,rect,0.020833,0.015625"
 overlay0_desc101 = "menu_toggle,0.979167,0.784722,rect,0.020833,0.015625"
 overlay0_desc102 = "osk_toggle,0.935185,0.784722,rect,0.020833,0.015625"
+# nul area to block mouse
+overlay0_desc103 = "nul,0.5,0.8835,rect,0.5,0.1148"


### PR DESCRIPTION
This covers each keyboard with an invisible 'nul' button, which is enough for RetroArch to set its `INP_FLAG_BLOCK_POINTER_INPUT` flag and prevent accidental touchscreen/overlay mouse input between keys.