### PR TITLE
move some null buttons offscreen 

### DIFF
--- a/gamepads/Named_Overlays/Nintendo - Nintendo DS.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo DS.cfg
@@ -60,12 +60,12 @@ overlay0_desc13_overlay = ../flat/img/select_rounded_big.png
 
 overlay0_desc14 = "l,0.02917,0.50556,rect,0.04896,0.05370"
 overlay0_desc14_overlay = ../flat/img/L_smaller.png
-overlay0_desc15 = "nul,0.76458,0.94815,rect,0.03229,0.08704"
+overlay0_desc15 = "nul,1.76458,0.94815,rect,0.03229,0.08704"
 #overlay0_desc15_overlay = ../flat/img/L_down_smaller_gba.png
 overlay0_desc16 = "r,0.97083,0.50556,rect,0.04896,0.05370"
 overlay0_desc16_overlay = ../flat/img/R_smaller.png
 
-overlay0_desc17 = "nul,0.64688,0.94815,rect,0.05416,0.09259"
+overlay0_desc17 = "nul,1.64688,0.94815,rect,0.05416,0.09259"
 #overlay0_desc17_overlay = ../flat/img/L_and_R_down.png
 
 overlay0_desc18 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.046296"

--- a/gamepads/Named_Overlays/Nintendo - Nintendo DSi.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo DSi.cfg
@@ -60,12 +60,12 @@ overlay0_desc13_overlay = ../flat/img/select_rounded_big.png
 
 overlay0_desc14 = "l,0.02917,0.50556,rect,0.04896,0.05370"
 overlay0_desc14_overlay = ../flat/img/L_smaller.png
-overlay0_desc15 = "nul,0.76458,0.94815,rect,0.03229,0.08704"
+overlay0_desc15 = "nul,1.76458,0.94815,rect,0.03229,0.08704"
 #overlay0_desc15_overlay = ../flat/img/L_down_smaller_gba.png
 overlay0_desc16 = "r,0.97083,0.50556,rect,0.04896,0.05370"
 overlay0_desc16_overlay = ../flat/img/R_smaller.png
 
-overlay0_desc17 = "nul,0.64688,0.94815,rect,0.05416,0.09259"
+overlay0_desc17 = "nul,1.64688,0.94815,rect,0.05416,0.09259"
 #overlay0_desc17_overlay = ../flat/img/L_and_R_down.png
 
 overlay0_desc18 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.046296"

--- a/gamepads/neo-ds-portrait/neo-ds-portrait.cfg
+++ b/gamepads/neo-ds-portrait/neo-ds-portrait.cfg
@@ -23,9 +23,9 @@ overlay1_alpha_mod = 2.0
 overlay0_descs = 39
 
 # D-Pad
-overlay0_desc0 = "dpad_area,0.21606118546845123896,0.90440860215053762605,rect,0.159259,0.089583"
-overlay0_desc0_reach_x = 1.9
-overlay0_desc0_reach_y = 1.6
+overlay0_desc0 = "dpad_area,0.21606118546845123896,0.90440860215053762605,radial,0.159259,0.089583"
+overlay0_desc0_reach_x = 1.3
+overlay0_desc0_reach_y = 1.3
 overlay0_desc0_range_mod = 1.1
 overlay0_desc0_range_mod_exclusive = true
 
@@ -78,9 +78,9 @@ overlay0_desc12 = "up|right,0.33556405353728491203,0.83720430107526886854,rect,0
 overlay0_desc12_reach_x = 0
 
 # ABXY
-overlay0_desc13 = "abxy_area,0.78393881453154878880,0.90440860215053762605,rect,0.159259,0.089583"
-overlay0_desc13_reach_x = 1.4
-overlay0_desc13_reach_y = 1.4
+overlay0_desc13 = "abxy_area,0.78393881453154878880,0.90440860215053762605,radial,0.159259,0.089583"
+overlay0_desc13_reach_x = 1.3
+overlay0_desc13_reach_y = 1.3
 overlay0_desc13_range_mod = 1.1
 overlay0_desc13_range_mod_exclusive = true
 
@@ -122,13 +122,13 @@ overlay0_desc20_reach_x = 1.2
 overlay0_desc20_reach_y = 2.0
 overlay0_desc20_exclusive = true
 
-overlay0_desc21 = "nul,0.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay0_desc21 = "nul,1.20650095602294454844,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
 #overlay0_desc21_overlay = "img/clear/button_l2.png"
 #overlay0_desc21_reach_x = 1.6
 #overlay0_desc21_reach_y = 2.0
 #overlay0_desc21_exclusive = true
 
-overlay0_desc22 = "nul,0.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay0_desc22 = "nul,1.34416826003824091407,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
 #overlay0_desc22_overlay = "img/clear/button_l3.png"
 #overlay0_desc22_reach_x = 1.6
 #overlay0_desc22_reach_y = 2.0
@@ -140,20 +140,20 @@ overlay0_desc23_reach_x = 1.2
 overlay0_desc23_reach_y = 2.0
 overlay0_desc23_exclusive = true
 
-overlay0_desc24 = "nul,0.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
+overlay0_desc24 = "nul,1.79349904397705539605,0.83763440860215054862,rect,0.05353728489483747938,0.02580645161290322578"
 #overlay0_desc24_overlay = "img/clear/button_r2.png"
 #overlay0_desc24_reach_x = 1.6
 #overlay0_desc24_reach_y = 2.0
 #overlay0_desc24_exclusive = true
 
-overlay0_desc25 = "nul,0.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
+overlay0_desc25 = "nul,1.65583173996175903042,0.88924731182795702100,rect,0.05353728489483747938,0.02580645161290322578"
 #overlay0_desc25_overlay = "img/clear/button_r3.png"
 #overlay0_desc25_reach_x = 1.6
 #overlay0_desc25_reach_y = 2.0
 #overlay0_desc25_exclusive = true
 
 # Hotkeys
-overlay0_desc26 = "nul,0.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
+overlay0_desc26 = "nul,1.05353728489483747938,0.89354838709677419928,radial,0.03824091778202676900,0.02150537634408602322"
 #overlay0_desc26_next_target = "portrait-analog"
 #overlay0_desc26_overlay = "img/clear/hotkey_analog.png"
 #overlay0_desc26_reach_x = 1.6
@@ -177,7 +177,7 @@ overlay0_desc29_reach_y = 1.6
 overlay0_desc29_exclusive = true
 
 # Invisible rotate hotkey
-overlay0_desc30 = "nul,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
+overlay0_desc30 = "nul,1.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
 #overlay0_desc30_next_target = "landscape-digital"
 #overlay0_desc30_overlay = "img/clear/test_64x64.png"
 
@@ -210,6 +210,6 @@ overlay1_desc0_reach_x = 1.6
 overlay1_desc0_reach_y = 1.6
 
 # Invisible rotate hotkey
-overlay1_desc1 = "nul,0.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
+overlay1_desc1 = "nul,1.50000000000000000000,0.02473118279569892428,radial,0.03824091778202676900,0.02150537634408602322"
 #overlay1_desc1_next_target = "landscape-hidden-digital"
 #overlay1_desc1_overlay = "img/clear/test_64x64.png"


### PR DESCRIPTION
and reduce the reach of the canned abxy area to avoid conflicts with the fast-forward button