### PR TITLE
fix opt1/2 assignments

### DIFF
--- a/gamepads/Named_Overlays/Atari - Lynx.cfg
+++ b/gamepads/Named_Overlays/Atari - Lynx.cfg
@@ -55,10 +55,10 @@ overlay0_desc9_overlay = ../flat/img/B.png
 overlay0_desc10 = "a|b,0.87500,0.32060,radial,0.01389,0.02469"
 overlay0_desc11 = "a|b,0.88125,0.34977,radial,0.01389,0.02469"
 
-overlay0_desc12 = "start,0.93750,0.65185,radial,0.04583,0.03889"
+overlay0_desc12 = "l,0.93750,0.65185,radial,0.04583,0.03889"
 overlay0_desc12_overlay = ../flat/img/lynx_option1.png
 
-overlay0_desc13 = "select,0.93750,0.80185,radial,0.04583,0.03889"
+overlay0_desc13 = "r,0.93750,0.80185,radial,0.04583,0.03889"
 overlay0_desc13_overlay = ../flat/img/lynx_option2.png
 
 overlay0_desc14 = "overlay_next,0.93750,0.95185,radial,0.04583,0.03889"
@@ -102,10 +102,10 @@ overlay1_desc9_overlay = ../flat/img/B.png
 overlay1_desc10 = "a|b,0.77778,0.68033,radial,0.02469,0.01389"
 overlay1_desc11 = "a|b,0.78889,0.69674,radial,0.02469,0.01389"
 
-overlay1_desc12 = "start,0.88889,0.52604,radial,0.08148,0.021875"
+overlay1_desc12 = "l,0.88889,0.52604,radial,0.08148,0.021875"
 overlay1_desc12_overlay = ../flat/img/start_genesis.png
 
-overlay1_desc13 = "select,0.11111,0.46354,radial,0.08148,0.021875"
+overlay1_desc13 = "r,0.11111,0.46354,radial,0.08148,0.021875"
 overlay1_desc13_overlay = ../flat/img/start_genesis.png
 
 overlay1_desc14 = "menu_toggle,0.50000,0.94792,radial,0.046296,0.02604"
@@ -151,10 +151,10 @@ overlay3_desc9_overlay = ../flat/img/B.png
 overlay3_desc10 = "a|b,0.125,0.32060,radial,0.01389,0.02469"
 overlay3_desc11 = "a|b,0.11875,0.34977,radial,0.01389,0.02469"
 
-overlay3_desc12 = "start,0.0625,0.95185,radial,0.04583,0.03889"
+overlay3_desc12 = "l,0.0625,0.95185,radial,0.04583,0.03889"
 overlay3_desc12_overlay = ../flat/img/lynx_option1.png
 
-overlay3_desc13 = "select,0.0625,0.80185,radial,0.04583,0.03889"
+overlay3_desc13 = "r,0.0625,0.80185,radial,0.04583,0.03889"
 overlay3_desc13_overlay = ../flat/img/lynx_option2.png
 
 overlay3_desc14 = "overlay_next,0.0625,0.65185,radial,0.04583,0.03889"


### PR DESCRIPTION
lynx overlay was sending wrong retropad commands