### PR TITLE
Rewrite DS / DSi overlays

### DIFF
--- a/gamepads/Named_Overlays/Nintendo - Nintendo DS.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo DS.cfg
@@ -1,20 +1,20 @@
 overlays = 3
 
-overlay0_name = "landscape"
+overlay0_name = "portrait"
 overlay0_full_screen = true
 overlay0_normalized = true
-overlay0_aspect_ratio = 1.77777778
+overlay0_aspect_ratio = 0.5623
 overlay0_block_x_separation = false
-overlay0_block_y_separation = false
+overlay0_block_y_separation = true
 overlay0_range_mod = 1.5
 overlay0_alpha_mod = 2.0
 
-overlay1_name = "portrait"
+overlay1_name = "landscape"
 overlay1_full_screen = true
 overlay1_normalized = true
-overlay1_aspect_ratio = 0.56236559139784946237
+overlay1_aspect_ratio = 1.77777778
 overlay1_block_x_separation = false
-overlay1_block_y_separation = true
+overlay1_block_y_separation = false
 overlay1_range_mod = 1.5
 overlay1_alpha_mod = 2.0
 
@@ -27,189 +27,161 @@ overlay2_block_y_separation = false
 overlay2_range_mod = 1.5
 overlay2_alpha_mod = 2.0
 
-
-# Overlay 0 - landscape
-overlay0_descs = 31
-
-overlay0_desc0 = "left,0.07188,0.77778,radial,0.04479,0.06852"
-overlay0_desc0_overlay = ../flat/img/dpad-left.png
-overlay0_desc1 = "right,0.17813,0.77778,radial,0.04479,0.06852"
-overlay0_desc1_overlay = ../flat/img/dpad-right.png
-overlay0_desc2 = "up,0.12500,0.68333,radial,0.03854,0.07963"
-overlay0_desc2_overlay = ../flat/img/dpad-up.png
-overlay0_desc3 = "down,0.12500,0.87222,radial,0.03854,0.07963"
-overlay0_desc3_overlay = ../flat/img/dpad-down.png
-overlay0_desc4 = "left|up,0.05625,0.65556,rect,0.03021,0.05370"
-overlay0_desc5 = "right|up,0.19375,0.65556,rect,0.03021,0.05370"
-overlay0_desc6 = "left|down,0.05625,0.90000,rect,0.03021,0.05370"
-overlay0_desc7 = "right|down,0.19375,0.90000,rect,0.03021,0.05370"
-
-overlay0_desc8 = "a,0.92188,0.75000,radial,0.04167,0.07407"
-overlay0_desc8_overlay = ../flat/img/A.png
-overlay0_desc9 = "b,0.85938,0.86111,radial,0.04167,0.07407"
-overlay0_desc9_overlay = ../flat/img/B.png
-overlay0_desc10 = "x,0.85938,0.63889,radial,0.04167,0.07407"
-overlay0_desc10_overlay = ../flat/img/X.png
-overlay0_desc11 = "y,0.79688,0.75000,radial,0.04167,0.07407"
-overlay0_desc11_overlay = ../flat/img/Y.png
-
-overlay0_desc12 = "start,0.93750,0.28889,rect,0.03958,0.07037"
-overlay0_desc12_overlay = ../flat/img/start_rounded_big.png
-overlay0_desc13 = "select,0.06250,0.28889,rect,0.03958,0.07037"
-overlay0_desc13_overlay = ../flat/img/select_rounded_big.png
-
-overlay0_desc14 = "l,0.02917,0.50556,rect,0.04896,0.05370"
-overlay0_desc14_overlay = ../flat/img/L_smaller.png
-overlay0_desc15 = "nul,1.76458,0.94815,rect,0.03229,0.08704"
-#overlay0_desc15_overlay = ../flat/img/L_down_smaller_gba.png
-overlay0_desc16 = "r,0.97083,0.50556,rect,0.04896,0.05370"
-overlay0_desc16_overlay = ../flat/img/R_smaller.png
-
-overlay0_desc17 = "nul,1.64688,0.94815,rect,0.05416,0.09259"
-#overlay0_desc17_overlay = ../flat/img/L_and_R_down.png
-
-overlay0_desc18 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.046296"
-overlay0_desc18_overlay = ../flat/img/rgui.png
-
-# invisible rotate button
-overlay0_desc19 = "overlay_next,2.5,2.5,radial,0.1,0.1"
-overlay0_desc19_next_target = "portrait"
-
-overlay0_desc20 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
-overlay0_desc20_overlay = ../flat/img/hide.png
-overlay0_desc20_next_target = "hidden"
-
-# Combo buttons
-overlay0_desc21 = "x|y,0.82188,0.68333,radial,0.01389,0.02469"
-overlay0_desc22 = "x|y,0.83438,0.70556,radial,0.01389,0.02469"
-
-overlay0_desc23 = "a|b,0.88438,0.79444,radial,0.01389,0.02469"
-overlay0_desc24 = "a|b,0.89688,0.81667,radial,0.01389,0.02469"
-
-overlay0_desc25 = "y|b,0.82188,0.81667,radial,0.01389,0.02469"
-overlay0_desc26 = "y|b,0.83438,0.79444,radial,0.01389,0.02469"
-
-overlay0_desc27 = "x|a,0.88438,0.70556,radial,0.01389,0.02469"
-overlay0_desc28 = "x|a,0.89688,0.68333,radial,0.01389,0.02469"
-
-overlay0_desc29 = "r2|r3,0.06250,0.08889,radial,0.02604,0.046296"
-overlay0_desc29_overlay = ../flat/img/2-button_gba_modified.png
-
-overlay0_desc30 = "toggle_fast_forward,0.20000,0.08889,radial,0.02604,0.046296"
-overlay0_desc30_overlay = ../flat/img/fast_forward.png
-
-
-## Overlay 1: portrait
-overlay1_descs = 33
+########################################
+## Overlay 0: portrait
+overlay0_descs = 23
 
 # D-Pad
+overlay0_desc0 = "down,0.21606,0.95333,rect,0.06118,0.04247"
+overlay0_desc0_overlay = "../flat/img/dpad-down.png"
+overlay0_desc1 = "left,0.12906,0.90440,rect,0.07552,0.03440"
+overlay0_desc1_overlay = "../flat/img/dpad-left.png"
+overlay0_desc2 = "right,0.3030,0.90440,rect,0.07552,0.03440"
+overlay0_desc2_overlay = "../flat/img/dpad-right.png"
+overlay0_desc3 = "up,0.21606,0.85548,rect,0.06118,0.04247"
+overlay0_desc3_overlay = "../flat/img/dpad-up.png"
 
-overlay1_desc0 = "down,0.21606118546845123896,0.95333333333333334814,rect,0.06118546845124282763,0.04247311827956989222"
-overlay1_desc0_overlay = "../flat/img/dpad-down.png"
-
-overlay1_desc1 = "left,0.12906309751434033584,0.90440860215053762605,rect,0.07552581261950286340,0.03440860215053763438"
-overlay1_desc1_overlay = "../flat/img/dpad-left.png"
-
-overlay1_desc2 = "right,0.30305927342256211432,0.90440860215053762605,rect,0.07552581261950286340,0.03440860215053763438"
-overlay1_desc2_overlay = "../flat/img/dpad-right.png"
-
-overlay1_desc3 = "up,0.21606118546845123896,0.85548387096774190397,rect,0.06118546845124282763,0.04247311827956989222"
-overlay1_desc3_overlay = "../flat/img/dpad-up.png"
-
-overlay1_desc4 = "down,0.21606118546845123896,0.97456989247311829772,rect,0.06118546845124282763,0.02123655913978494611"
-overlay1_desc5 = "left,0.09130019120458890414,0.90440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
-overlay1_desc6 = "right,0.34082217973231360153,0.93440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
-overlay1_desc7 = "up,0.21606118546845123896,0.83424731182795695439,rect,0.06118546845124282763,0.02123655913978494611"
-overlay1_desc8 = "down|left,0.09655831739961759363,0.97161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
-overlay1_desc9 = "down|right,0.33556405353728491203,0.97161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
-overlay1_desc10 = "up|left,0.09655831739961759363,0.83720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
-overlay1_desc11 = "up|right,0.33556405353728491203,0.83720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
+# D-Pad diagonals
+overlay0_desc4 = "down|left,0.09655,0.97161,rect,0.04302,0.02419"
+overlay0_desc5 = "down|right,0.33556,0.97161,rect,0.04302,0.02419"
+overlay0_desc6 = "up|left,0.09655,0.83720,rect,0.04302,0.02419"
+overlay0_desc7 = "up|right,0.33556,0.83720,rect,0.04302,0.02419"
 
 # ABXY
-overlay1_desc12 = "abxy_area,0.78393881453154878880,0.90440860215053762605,rect,0.159259,0.089583"
-overlay1_desc12_reach_x = 1.4
-overlay1_desc12_reach_y = 1.4
-overlay1_desc12_range_mod = 1.1
-overlay1_desc12_range_mod_exclusive = true
+overlay0_desc8 = "a,0.88527,0.90440,rect,0.06118,0.03440"
+overlay0_desc8_overlay = "../flat/img/A.png"
+overlay0_desc9 = "b,0.78393,0.96139,rect,0.06118,0.03440"
+overlay0_desc9_overlay = "../flat/img/B.png"
+overlay0_desc10 = "x,0.78393,0.84741,rect,0.06118,0.03440"
+overlay0_desc10_overlay = "../flat/img/X.png"
+overlay0_desc11 = "y,0.68260,0.90440,rect,0.06118,0.03440"
+overlay0_desc11_overlay = "../flat/img/Y.png"
 
-overlay1_desc13 = "a,0.88527724665391971381,0.90440860215053762605,rect,0.06118546845124282763,0.03440860215053763438"
-overlay1_desc13_overlay = "../flat/img/A.png"
-overlay1_desc13_reach_x = 0
+# Select button
+overlay0_desc12 = "select,0.46,0.96,rect,0.035,0.02"
+overlay0_desc12_overlay = "../flat/img/select_rounded_big.png"
+overlay0_desc12_reach_left = 1.2
+overlay0_desc12_reach_right = 1.6
+overlay0_desc12_reach_y = 1.6
+overlay0_desc12_exclusive = true
 
-overlay1_desc14 = "b,0.78393881453154878880,0.96139784946236559904,rect,0.06118546845124282763,0.03440860215053763438"
-overlay1_desc14_overlay = "../flat/img/B.png"
-overlay1_desc14_reach_x = 0
+# Start button
+overlay0_desc13 = "start,0.54,0.96,rect,0.035,0.02"
+overlay0_desc13_overlay = "../flat/img/start_rounded_big.png"
+overlay0_desc13_reach_right = 1.2
+overlay0_desc13_reach_left = 1.6
+overlay0_desc13_reach_y = 1.6
+overlay0_desc13_exclusive = true
 
-overlay1_desc15 = "x,0.78393881453154878880,0.84741935483870965307,rect,0.06118546845124282763,0.03440860215053763438"
-overlay1_desc15_overlay = "../flat/img/X.png"
-overlay1_desc15_reach_x = 0
+# L button
+overlay0_desc14 = "l,0.1,0.77,rect,0.065,0.0228"
+overlay0_desc14_overlay = "../flat/img/L_smaller.png"
+overlay0_desc14_reach_x = 1.2
+overlay0_desc14_reach_y = 2.0
+overlay0_desc14_exclusive = true
 
-overlay1_desc16 = "y,0.68260038240917786379,0.90440860215053762605,rect,0.06118546845124282763,0.03440860215053763438"
-overlay1_desc16_overlay = "../flat/img/Y.png"
-overlay1_desc16_reach_x = 0
-
-# Select/start
-overlay1_desc17 = "select,0.465,0.96,rect,0.035,0.02"
-overlay1_desc17_overlay = "../flat/img/select_rounded_big.png"
-overlay1_desc17_reach_left = 1.2
-overlay1_desc17_reach_right = 1.6
-overlay1_desc17_reach_y = 1.6
-overlay1_desc17_exclusive = true
-
-overlay1_desc18 = "start,0.535,0.96,rect,0.035,0.02"
-overlay1_desc18_overlay = "../flat/img/start_rounded_big.png"
-overlay1_desc18_reach_right = 1.2
-overlay1_desc18_reach_left = 1.6
-overlay1_desc18_reach_y = 1.6
-overlay1_desc18_exclusive = true
-
-# L/R buttons
-overlay1_desc19 = "l,0.1,0.77,rect,0.065,0.02280645161290322578"
-overlay1_desc19_overlay = "../flat/img/L_smaller.png"
-overlay1_desc19_reach_x = 1.2
-overlay1_desc19_reach_y = 2.0
-overlay1_desc19_exclusive = true
-
-overlay1_desc20 = "r,0.9,0.77,rect,0.065,0.02280645161290322578"
-overlay1_desc20_overlay = "../flat/img/R_smaller.png"
-overlay1_desc20_reach_x = 1.2
-overlay1_desc20_reach_y = 2.0
-overlay1_desc20_exclusive = true
-
-# Hotkeys
-overlay1_desc21 = "menu_toggle,0.5,0.84440860215053762605,radial,0.035,0.02"
-overlay1_desc21_overlay = "../flat/img/rgui.png"
-overlay1_desc21_reach_x = 1.67
-overlay1_desc21_reach_y = 1.6
-overlay1_desc21_exclusive = true
-
-# Invisible rotate hotkey
-overlay1_desc22 = "overlay_next,2.5,2.5,radial,0.1,0.1"
-overlay1_desc22_next_target = "landscape"
+# R button
+overlay0_desc15 = "r,0.9,0.77,rect,0.065,0.02280"
+overlay0_desc15_overlay = "../flat/img/R_smaller.png"
+overlay0_desc15_reach_x = 1.2
+overlay0_desc15_reach_y = 2.0
+overlay0_desc15_exclusive = true
 
 # Combo buttons
-overlay1_desc23 = "x|y,0.719336,0.796733,radial,0.02469,0.01389"
-overlay1_desc24 = "x|y,0.744591,0.814428,radial,0.02469,0.01389"
-overlay1_desc25 = "a|b,0.826904,0.857957,radial,0.02469,0.01389"
-overlay1_desc26 = "a|b,0.847057,0.875652,radial,0.02469,0.01389"
-overlay1_desc27 = "y|b,0.722737,0.871116,radial,0.02469,0.01389"
-overlay1_desc28 = "y|b,0.742891,0.857957,radial,0.02469,0.01389"
-overlay1_desc29 = "x|a,0.828605,0.811027,radial,0.02469,0.01389"
-overlay1_desc30 = "x|a,0.847908,0.796733,radial,0.02469,0.01389"
+overlay0_desc16 = "x|y,0.68260,0.84741,radial,0.02469,0.01389"
+overlay0_desc17 = "a|b,0.88527,0.96139,radial,0.02469,0.01389"
+overlay0_desc18 = "y|b,0.68260,0.96139,radial,0.02469,0.01389"
+overlay0_desc19 = "x|a,0.88527,0.84741,radial,0.02469,0.01389"
 
-overlay1_desc31 = "r2|r3,0.465,0.90,radial,0.035,0.02"
-overlay1_desc31_overlay = "../flat/img/2-button_gba_modified.png"
+# Menu button
+overlay0_desc20 = "menu_toggle,0.5,0.77,radial,0.035,0.02"
+overlay0_desc20_overlay = "../flat/img/rgui.png"
+overlay0_desc20_reach_x = 1.67
+overlay0_desc20_reach_y = 1.6
+overlay0_desc20_exclusive = true
 
-overlay1_desc32 = "toggle_fast_forward,0.535,0.90,radial,0.035,0.02"
-overlay1_desc32_overlay = "../flat/img/fast_forward.png"
+# Tap stylus + quick screen switch
+overlay0_desc21 = "r2|r3,0.5,0.835,radial,0.035,0.02"
+overlay0_desc21_overlay = "../flat/img/2-button_gba_modified.png"
 
+# Rotate overlay
+overlay0_desc22 = "overlay_next,0.5,0.90,radial,0.035,0.02"
+overlay0_desc22_overlay = "../flat/img/rotate.png"
+overlay0_desc22_next_target = "landscape"
 
+########################################
+## Overlay 1: landscape
+overlay1_descs = 24
+
+# D-Pad
+overlay1_desc0 = "left,0.07188,0.77778,radial,0.04479,0.06852"
+overlay1_desc0_overlay = ../flat/img/dpad-left.png
+overlay1_desc1 = "right,0.17813,0.77778,radial,0.04479,0.06852"
+overlay1_desc1_overlay = ../flat/img/dpad-right.png
+overlay1_desc2 = "up,0.12500,0.68333,radial,0.03854,0.07963"
+overlay1_desc2_overlay = ../flat/img/dpad-up.png
+overlay1_desc3 = "down,0.12500,0.87222,radial,0.03854,0.07963"
+overlay1_desc3_overlay = ../flat/img/dpad-down.png
+
+# D-Pad diagonals
+overlay1_desc4 = "left|up,0.05625,0.65556,rect,0.03021,0.05370"
+overlay1_desc5 = "right|up,0.19375,0.65556,rect,0.03021,0.05370"
+overlay1_desc6 = "left|down,0.05625,0.90000,rect,0.03021,0.05370"
+overlay1_desc7 = "right|down,0.19375,0.90000,rect,0.03021,0.05370"
+
+# ABXY
+overlay1_desc8 = "a,0.92188,0.75000,radial,0.04167,0.07407"
+overlay1_desc8_overlay = ../flat/img/A.png
+overlay1_desc9 = "b,0.85938,0.86111,radial,0.04167,0.07407"
+overlay1_desc9_overlay = ../flat/img/B.png
+overlay1_desc10 = "x,0.85938,0.63889,radial,0.04167,0.07407"
+overlay1_desc10_overlay = ../flat/img/X.png
+overlay1_desc11 = "y,0.79688,0.75000,radial,0.04167,0.07407"
+overlay1_desc11_overlay = ../flat/img/Y.png
+
+# Select/Start buttons
+overlay1_desc12 = "select,0.06250,0.28889,rect,0.03958,0.07037"
+overlay1_desc12_overlay = ../flat/img/select_rounded_big.png
+overlay1_desc13 = "start,0.93750,0.28889,rect,0.03958,0.07037"
+overlay1_desc13_overlay = ../flat/img/start_rounded_big.png
+
+# L/R buttons
+overlay1_desc14 = "l,0.02917,0.50556,rect,0.04896,0.05370"
+overlay1_desc14_overlay = ../flat/img/L_smaller.png
+overlay1_desc15 = "r,0.97083,0.50556,rect,0.04896,0.05370"
+overlay1_desc15_overlay = ../flat/img/R_smaller.png
+
+# Combo buttons
+overlay1_desc16 = "x|y,0.79688,0.63889,radial,0.01389,0.02469"
+overlay1_desc17 = "a|b,0.92188,0.86111,radial,0.01389,0.02469"
+overlay1_desc18 = "y|b,0.79688,0.86111,radial,0.01389,0.02469"
+overlay1_desc19 = "x|a,0.92188,0.63889,radial,0.01389,0.02469"
+
+# Tap stylus + quick screen switch
+overlay1_desc20 = "r2|r3,0.06250,0.08889,radial,0.02604,0.046296"
+overlay1_desc20_overlay = ../flat/img/2-button_gba_modified.png
+
+# Menu button
+overlay1_desc21 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.04629"
+overlay1_desc21_overlay = ../flat/img/rgui.png
+
+# Hide overlay
+overlay1_desc22 = "overlay_next,0.80000,0.08889,radial,0.02604,0.04629"
+overlay1_desc22_overlay = ../flat/img/hide.png
+overlay1_desc22_next_target = "hidden"
+
+# Rotate overlay
+overlay1_desc23 = "overlay_next,0.20000,0.08889,radial,0.02604,0.04629"
+overlay1_desc23_overlay = ../flat/img/rotate.png
+overlay1_desc23_next_target = "portrait"
+
+########################################
 ## Overlay 2: hidden
 overlay2_descs = 1
 
-# Show hotkey
-overlay2_desc0 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
-overlay2_desc0_next_target = "landscape"
+# Show overlay
+overlay2_desc0 = "overlay_next,0.80000,0.08889,radial,0.02604,0.04629"
+overlay2_desc0_next_target = "portrait"
 overlay2_desc0_overlay = "../flat/img/show.png"
 overlay2_desc0_reach_x = 1.6
 overlay2_desc0_reach_y = 1.6

--- a/gamepads/Named_Overlays/Nintendo - Nintendo DS.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo DS.cfg
@@ -1,20 +1,20 @@
 overlays = 3
 
-overlay0_name = "portrait"
+overlay0_name = "landscape"
 overlay0_full_screen = true
 overlay0_normalized = true
-overlay0_aspect_ratio = 0.5623
+overlay0_aspect_ratio = 1.77777778
 overlay0_block_x_separation = false
-overlay0_block_y_separation = true
+overlay0_block_y_separation = false
 overlay0_range_mod = 1.5
 overlay0_alpha_mod = 2.0
 
-overlay1_name = "landscape"
+overlay1_name = "portrait"
 overlay1_full_screen = true
 overlay1_normalized = true
-overlay1_aspect_ratio = 1.77777778
+overlay1_aspect_ratio = 0.56236559
 overlay1_block_x_separation = false
-overlay1_block_y_separation = false
+overlay1_block_y_separation = true
 overlay1_range_mod = 1.5
 overlay1_alpha_mod = 2.0
 
@@ -27,161 +27,195 @@ overlay2_block_y_separation = false
 overlay2_range_mod = 1.5
 overlay2_alpha_mod = 2.0
 
-########################################
-## Overlay 0: portrait
-overlay0_descs = 23
+
+## Overlay 0: landscape
+overlay0_descs = 30
 
 # D-Pad
-overlay0_desc0 = "down,0.21606,0.95333,rect,0.06118,0.04247"
-overlay0_desc0_overlay = "../flat/img/dpad-down.png"
-overlay0_desc1 = "left,0.12906,0.90440,rect,0.07552,0.03440"
-overlay0_desc1_overlay = "../flat/img/dpad-left.png"
-overlay0_desc2 = "right,0.3030,0.90440,rect,0.07552,0.03440"
-overlay0_desc2_overlay = "../flat/img/dpad-right.png"
-overlay0_desc3 = "up,0.21606,0.85548,rect,0.06118,0.04247"
-overlay0_desc3_overlay = "../flat/img/dpad-up.png"
+overlay0_desc0 = "left,0.07188,0.77778,radial,0.04479,0.06852"
+overlay0_desc0_overlay = ../flat/img/dpad-left.png
+overlay0_desc1 = "right,0.17813,0.77778,radial,0.04479,0.06852"
+overlay0_desc1_overlay = ../flat/img/dpad-right.png
+overlay0_desc2 = "up,0.12500,0.68333,radial,0.03854,0.07963"
+overlay0_desc2_overlay = ../flat/img/dpad-up.png
+overlay0_desc3 = "down,0.12500,0.87222,radial,0.03854,0.07963"
+overlay0_desc3_overlay = ../flat/img/dpad-down.png
 
-# D-Pad diagonals
-overlay0_desc4 = "down|left,0.09655,0.97161,rect,0.04302,0.02419"
-overlay0_desc5 = "down|right,0.33556,0.97161,rect,0.04302,0.02419"
-overlay0_desc6 = "up|left,0.09655,0.83720,rect,0.04302,0.02419"
-overlay0_desc7 = "up|right,0.33556,0.83720,rect,0.04302,0.02419"
-
-# ABXY
-overlay0_desc8 = "a,0.88527,0.90440,rect,0.06118,0.03440"
-overlay0_desc8_overlay = "../flat/img/A.png"
-overlay0_desc9 = "b,0.78393,0.96139,rect,0.06118,0.03440"
-overlay0_desc9_overlay = "../flat/img/B.png"
-overlay0_desc10 = "x,0.78393,0.84741,rect,0.06118,0.03440"
-overlay0_desc10_overlay = "../flat/img/X.png"
-overlay0_desc11 = "y,0.68260,0.90440,rect,0.06118,0.03440"
-overlay0_desc11_overlay = "../flat/img/Y.png"
-
-# Select button
-overlay0_desc12 = "select,0.46,0.96,rect,0.035,0.02"
-overlay0_desc12_overlay = "../flat/img/select_rounded_big.png"
-overlay0_desc12_reach_left = 1.2
-overlay0_desc12_reach_right = 1.6
-overlay0_desc12_reach_y = 1.6
-overlay0_desc12_exclusive = true
-
-# Start button
-overlay0_desc13 = "start,0.54,0.96,rect,0.035,0.02"
-overlay0_desc13_overlay = "../flat/img/start_rounded_big.png"
-overlay0_desc13_reach_right = 1.2
-overlay0_desc13_reach_left = 1.6
-overlay0_desc13_reach_y = 1.6
-overlay0_desc13_exclusive = true
-
-# L button
-overlay0_desc14 = "l,0.1,0.77,rect,0.065,0.0228"
-overlay0_desc14_overlay = "../flat/img/L_smaller.png"
-overlay0_desc14_reach_x = 1.2
-overlay0_desc14_reach_y = 2.0
-overlay0_desc14_exclusive = true
-
-# R button
-overlay0_desc15 = "r,0.9,0.77,rect,0.065,0.02280"
-overlay0_desc15_overlay = "../flat/img/R_smaller.png"
-overlay0_desc15_reach_x = 1.2
-overlay0_desc15_reach_y = 2.0
-overlay0_desc15_exclusive = true
-
-# Combo buttons
-overlay0_desc16 = "x|y,0.68260,0.84741,radial,0.02469,0.01389"
-overlay0_desc17 = "a|b,0.88527,0.96139,radial,0.02469,0.01389"
-overlay0_desc18 = "y|b,0.68260,0.96139,radial,0.02469,0.01389"
-overlay0_desc19 = "x|a,0.88527,0.84741,radial,0.02469,0.01389"
-
-# Menu button
-overlay0_desc20 = "menu_toggle,0.5,0.77,radial,0.035,0.02"
-overlay0_desc20_overlay = "../flat/img/rgui.png"
-overlay0_desc20_reach_x = 1.67
-overlay0_desc20_reach_y = 1.6
-overlay0_desc20_exclusive = true
-
-# Tap stylus + quick screen switch
-overlay0_desc21 = "r2|r3,0.5,0.835,radial,0.035,0.02"
-overlay0_desc21_overlay = "../flat/img/2-button_gba_modified.png"
-
-# Rotate overlay
-overlay0_desc22 = "overlay_next,0.5,0.90,radial,0.035,0.02"
-overlay0_desc22_overlay = "../flat/img/rotate.png"
-overlay0_desc22_next_target = "landscape"
-
-########################################
-## Overlay 1: landscape
-overlay1_descs = 24
-
-# D-Pad
-overlay1_desc0 = "left,0.07188,0.77778,radial,0.04479,0.06852"
-overlay1_desc0_overlay = ../flat/img/dpad-left.png
-overlay1_desc1 = "right,0.17813,0.77778,radial,0.04479,0.06852"
-overlay1_desc1_overlay = ../flat/img/dpad-right.png
-overlay1_desc2 = "up,0.12500,0.68333,radial,0.03854,0.07963"
-overlay1_desc2_overlay = ../flat/img/dpad-up.png
-overlay1_desc3 = "down,0.12500,0.87222,radial,0.03854,0.07963"
-overlay1_desc3_overlay = ../flat/img/dpad-down.png
-
-# D-Pad diagonals
-overlay1_desc4 = "left|up,0.05625,0.65556,rect,0.03021,0.05370"
-overlay1_desc5 = "right|up,0.19375,0.65556,rect,0.03021,0.05370"
-overlay1_desc6 = "left|down,0.05625,0.90000,rect,0.03021,0.05370"
-overlay1_desc7 = "right|down,0.19375,0.90000,rect,0.03021,0.05370"
+overlay0_desc4 = "left|up,0.05625,0.65556,rect,0.03021,0.05370"
+overlay0_desc5 = "right|up,0.19375,0.65556,rect,0.03021,0.05370"
+overlay0_desc6 = "left|down,0.05625,0.90000,rect,0.03021,0.05370"
+overlay0_desc7 = "right|down,0.19375,0.90000,rect,0.03021,0.05370"
 
 # ABXY
-overlay1_desc8 = "a,0.92188,0.75000,radial,0.04167,0.07407"
-overlay1_desc8_overlay = ../flat/img/A.png
-overlay1_desc9 = "b,0.85938,0.86111,radial,0.04167,0.07407"
-overlay1_desc9_overlay = ../flat/img/B.png
-overlay1_desc10 = "x,0.85938,0.63889,radial,0.04167,0.07407"
-overlay1_desc10_overlay = ../flat/img/X.png
-overlay1_desc11 = "y,0.79688,0.75000,radial,0.04167,0.07407"
-overlay1_desc11_overlay = ../flat/img/Y.png
+overlay0_desc8 = "abxy_area,0.85938,0.75,rect,0.102,0.181"
+overlay0_desc8_reach_x = 1.4
+overlay0_desc8_reach_y = 1.4
+overlay0_desc8_range_mod = 1.1
+overlay0_desc8_range_mod_exclusive = true
 
-# Select/Start buttons
-overlay1_desc12 = "select,0.06250,0.28889,rect,0.03958,0.07037"
-overlay1_desc12_overlay = ../flat/img/select_rounded_big.png
-overlay1_desc13 = "start,0.93750,0.28889,rect,0.03958,0.07037"
-overlay1_desc13_overlay = ../flat/img/start_rounded_big.png
+overlay0_desc9 = "a,0.92188,0.75000,radial,0.04167,0.07407"
+overlay0_desc9_overlay = ../flat/img/A.png
+
+overlay0_desc10 = "b,0.85938,0.86111,radial,0.04167,0.07407"
+overlay0_desc10_overlay = ../flat/img/B.png
+
+overlay0_desc11 = "x,0.85938,0.63889,radial,0.04167,0.07407"
+overlay0_desc11_overlay = ../flat/img/X.png
+
+overlay0_desc12 = "y,0.79688,0.75000,radial,0.04167,0.07407"
+overlay0_desc12_overlay = ../flat/img/Y.png
+
+# Select/start
+overlay0_desc13 = "start,0.93750,0.28889,rect,0.03958,0.07037"
+overlay0_desc13_overlay = ../flat/img/start_rounded_big.png
+
+overlay0_desc14 = "select,0.06250,0.28889,rect,0.03958,0.07037"
+overlay0_desc14_overlay = ../flat/img/select_rounded_big.png
 
 # L/R buttons
-overlay1_desc14 = "l,0.02917,0.50556,rect,0.04896,0.05370"
-overlay1_desc14_overlay = ../flat/img/L_smaller.png
-overlay1_desc15 = "r,0.97083,0.50556,rect,0.04896,0.05370"
-overlay1_desc15_overlay = ../flat/img/R_smaller.png
+overlay0_desc15 = "l,0.02917,0.50556,rect,0.04896,0.05370"
+overlay0_desc15_overlay = ../flat/img/L_smaller.png
 
-# Combo buttons
-overlay1_desc16 = "x|y,0.79688,0.63889,radial,0.01389,0.02469"
-overlay1_desc17 = "a|b,0.92188,0.86111,radial,0.01389,0.02469"
-overlay1_desc18 = "y|b,0.79688,0.86111,radial,0.01389,0.02469"
-overlay1_desc19 = "x|a,0.92188,0.63889,radial,0.01389,0.02469"
+overlay0_desc16 = "r,0.97083,0.50556,rect,0.04896,0.05370"
+overlay0_desc16_overlay = ../flat/img/R_smaller.png
 
-# Tap stylus + quick screen switch
-overlay1_desc20 = "r2|r3,0.06250,0.08889,radial,0.02604,0.046296"
-overlay1_desc20_overlay = ../flat/img/2-button_gba_modified.png
+# Menu
+overlay0_desc17 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.046296"
+overlay0_desc17_overlay = ../flat/img/rgui.png
 
-# Menu button
-overlay1_desc21 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.04629"
-overlay1_desc21_overlay = ../flat/img/rgui.png
+# Invisible rotate hotkey
+overlay0_desc18 = "overlay_next,2.5,2.5,radial,0.1,0.1"
+overlay0_desc18_next_target = "portrait"
 
-# Hide overlay
-overlay1_desc22 = "overlay_next,0.80000,0.08889,radial,0.02604,0.04629"
-overlay1_desc22_overlay = ../flat/img/hide.png
-overlay1_desc22_next_target = "hidden"
+overlay0_desc19 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
+overlay0_desc19_overlay = ../flat/img/hide.png
+overlay0_desc19_next_target = "hidden"
 
-# Rotate overlay
-overlay1_desc23 = "overlay_next,0.20000,0.08889,radial,0.02604,0.04629"
-overlay1_desc23_overlay = ../flat/img/rotate.png
-overlay1_desc23_next_target = "portrait"
+# ABXY combo buttons
+overlay0_desc20 = "x|y,0.82188,0.68333,radial,0.01389,0.02469"
+overlay0_desc21 = "x|y,0.83438,0.70556,radial,0.01389,0.02469"
 
-########################################
+overlay0_desc22 = "a|b,0.88438,0.79444,radial,0.01389,0.02469"
+overlay0_desc23 = "a|b,0.89688,0.81667,radial,0.01389,0.02469"
+
+overlay0_desc24 = "y|b,0.82188,0.81667,radial,0.01389,0.02469"
+overlay0_desc25 = "y|b,0.83438,0.79444,radial,0.01389,0.02469"
+
+overlay0_desc26 = "x|a,0.88438,0.70556,radial,0.01389,0.02469"
+overlay0_desc27 = "x|a,0.89688,0.68333,radial,0.01389,0.02469"
+
+# Switch screens
+overlay0_desc28 = "r2|r3,0.06250,0.08889,radial,0.02604,0.046296"
+overlay0_desc28_overlay = ../flat/img/2-button_gba_modified.png
+
+# Fast forward
+overlay0_desc29 = "toggle_fast_forward,0.20000,0.08889,radial,0.02604,0.046296"
+overlay0_desc29_overlay = ../flat/img/fast_forward.png
+
+
+## Overlay 1: portrait
+overlay1_descs = 29
+
+# D-Pad
+overlay1_desc0 = "down,0.21606,0.95333,radial,0.06118,0.04247"
+overlay1_desc0_overlay = dpad-down.png
+overlay1_desc1 = "left,0.12906,0.90440,radial,0.07552,0.03440"
+overlay1_desc1_overlay = dpad-left.png
+overlay1_desc2 = "right,0.30305,0.90440,radial,0.07552,0.03440"
+overlay1_desc2_overlay = dpad-right.png
+overlay1_desc3 = "up,0.21606,0.85548,radial,0.06118,0.04247"
+overlay1_desc3_overlay = dpad-up.png
+overlay1_desc4 = "down|left,0.1,0.968,rect,0.053,0.027"
+overlay1_desc5 = "down|right,0.333,0.968,rect,0.053,0.027"
+overlay1_desc6 = "up|left,0.1,0.842,rect,0.053,0.027"
+overlay1_desc7 = "up|right,0.333,0.842,rect,0.053,0.027"
+
+# ABXY
+overlay1_desc8 = "abxy_area,0.78393,0.90440,rect,0.159259,0.089583"
+overlay1_desc8_reach_x = 1.4
+overlay1_desc8_reach_y = 1.4
+overlay1_desc8_range_mod = 1.1
+overlay1_desc8_range_mod_exclusive = true
+
+overlay1_desc9 = "a,0.88527,0.90440,radial,0.06118,0.03440"
+overlay1_desc9_overlay = A.png
+
+overlay1_desc10 = "b,0.78393,0.96139,radial,0.06118,0.03440"
+overlay1_desc10_overlay = B.png
+
+overlay1_desc11 = "x,0.78393,0.84741,radial,0.06118,0.03440"
+overlay1_desc11_overlay = X.png
+
+overlay1_desc12 = "y,0.68260,0.90440,radial,0.06118,0.03440"
+overlay1_desc12_overlay = Y.png
+
+# Select/start
+overlay1_desc13 = "select,0.46,0.96,rect,0.035,0.02"
+overlay1_desc13_overlay = select_rounded_big.png
+overlay1_desc13_reach_left = 1.2
+overlay1_desc13_reach_right = 1.6
+overlay1_desc13_reach_y = 1.6
+overlay1_desc13_exclusive = true
+
+overlay1_desc14 = "start,0.54,0.96,rect,0.035,0.02"
+overlay1_desc14_overlay = start_rounded_big.png
+overlay1_desc14_reach_right = 1.2
+overlay1_desc14_reach_left = 1.6
+overlay1_desc14_reach_y = 1.6
+overlay1_desc14_exclusive = true
+
+# L/R buttons
+overlay1_desc15 = "l,0.1,0.77,rect,0.065,0.02280"
+overlay1_desc15_overlay = "../flat/img/L_smaller.png"
+overlay1_desc15_reach_x = 1.2
+overlay1_desc15_reach_y = 2.0
+overlay1_desc15_exclusive = true
+
+overlay1_desc16 = "r,0.9,0.77,rect,0.065,0.02280"
+overlay1_desc16_overlay = "../flat/img/R_smaller.png"
+overlay1_desc16_reach_x = 1.2
+overlay1_desc16_reach_y = 2.0
+overlay1_desc16_exclusive = true
+
+# Menu
+overlay1_desc17 = "menu_toggle,0.5,0.84440,radial,0.035,0.02"
+overlay1_desc17_overlay = "../flat/img/rgui.png"
+overlay1_desc17_reach_x = 1.67
+overlay1_desc17_reach_y = 1.6
+overlay1_desc17_exclusive = true
+
+# Invisible rotate hotkey
+overlay1_desc18 = "overlay_next,2.5,2.5,radial,0.1,0.1"
+overlay1_desc18_next_target = "landscape"
+
+# ABXY combo buttons
+overlay1_desc19 = "x|y,0.716,0.865,radial,0.02469,0.01389"
+overlay1_desc20 = "x|y,0.733,0.876,radial,0.02469,0.01389"
+
+overlay1_desc21 = "a|b,0.834,0.933,radial,0.02469,0.01389"
+overlay1_desc22 = "a|b,0.854,0.945,radial,0.02469,0.01389"
+
+overlay1_desc23 = "y|b,0.733,0.933,radial,0.02469,0.01389"
+overlay1_desc24 = "y|b,0.716,0.945,radial,0.02469,0.01389"
+
+overlay1_desc25 = "x|a,0.854,0.865,radial,0.02469,0.01389"
+overlay1_desc26 = "x|a,0.834,0.876,radial,0.02469,0.01389"
+
+# Switch screens
+overlay1_desc27 = "r2|r3,0.46,0.90,radial,0.035,0.02"
+overlay1_desc27_overlay = 2-button_gba_modified.png
+
+# Fast forward
+overlay1_desc28 = "toggle_fast_forward,0.54,0.90,radial,0.035,0.02"
+overlay1_desc28_overlay = fast_forward.png
+
+
 ## Overlay 2: hidden
 overlay2_descs = 1
 
-# Show overlay
-overlay2_desc0 = "overlay_next,0.80000,0.08889,radial,0.02604,0.04629"
-overlay2_desc0_next_target = "portrait"
+# Show hotkey
+overlay2_desc0 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
+overlay2_desc0_next_target = "landscape"
 overlay2_desc0_overlay = "../flat/img/show.png"
 overlay2_desc0_reach_x = 1.6
 overlay2_desc0_reach_y = 1.6

--- a/gamepads/Named_Overlays/Nintendo - Nintendo DSi.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo DSi.cfg
@@ -1,20 +1,20 @@
 overlays = 3
 
-overlay0_name = "portrait"
+overlay0_name = "landscape"
 overlay0_full_screen = true
 overlay0_normalized = true
-overlay0_aspect_ratio = 0.5623
+overlay0_aspect_ratio = 1.77777778
 overlay0_block_x_separation = false
-overlay0_block_y_separation = true
+overlay0_block_y_separation = false
 overlay0_range_mod = 1.5
 overlay0_alpha_mod = 2.0
 
-overlay1_name = "landscape"
+overlay1_name = "portrait"
 overlay1_full_screen = true
 overlay1_normalized = true
-overlay1_aspect_ratio = 1.77777778
+overlay1_aspect_ratio = 0.56236559
 overlay1_block_x_separation = false
-overlay1_block_y_separation = false
+overlay1_block_y_separation = true
 overlay1_range_mod = 1.5
 overlay1_alpha_mod = 2.0
 
@@ -27,161 +27,195 @@ overlay2_block_y_separation = false
 overlay2_range_mod = 1.5
 overlay2_alpha_mod = 2.0
 
-########################################
-## Overlay 0: portrait
-overlay0_descs = 23
+
+## Overlay 0: landscape
+overlay0_descs = 30
 
 # D-Pad
-overlay0_desc0 = "down,0.21606,0.95333,rect,0.06118,0.04247"
-overlay0_desc0_overlay = "../flat/img/dpad-down.png"
-overlay0_desc1 = "left,0.12906,0.90440,rect,0.07552,0.03440"
-overlay0_desc1_overlay = "../flat/img/dpad-left.png"
-overlay0_desc2 = "right,0.3030,0.90440,rect,0.07552,0.03440"
-overlay0_desc2_overlay = "../flat/img/dpad-right.png"
-overlay0_desc3 = "up,0.21606,0.85548,rect,0.06118,0.04247"
-overlay0_desc3_overlay = "../flat/img/dpad-up.png"
+overlay0_desc0 = "left,0.07188,0.77778,radial,0.04479,0.06852"
+overlay0_desc0_overlay = ../flat/img/dpad-left.png
+overlay0_desc1 = "right,0.17813,0.77778,radial,0.04479,0.06852"
+overlay0_desc1_overlay = ../flat/img/dpad-right.png
+overlay0_desc2 = "up,0.12500,0.68333,radial,0.03854,0.07963"
+overlay0_desc2_overlay = ../flat/img/dpad-up.png
+overlay0_desc3 = "down,0.12500,0.87222,radial,0.03854,0.07963"
+overlay0_desc3_overlay = ../flat/img/dpad-down.png
 
-# D-Pad diagonals
-overlay0_desc4 = "down|left,0.09655,0.97161,rect,0.04302,0.02419"
-overlay0_desc5 = "down|right,0.33556,0.97161,rect,0.04302,0.02419"
-overlay0_desc6 = "up|left,0.09655,0.83720,rect,0.04302,0.02419"
-overlay0_desc7 = "up|right,0.33556,0.83720,rect,0.04302,0.02419"
-
-# ABXY
-overlay0_desc8 = "a,0.88527,0.90440,rect,0.06118,0.03440"
-overlay0_desc8_overlay = "../flat/img/A.png"
-overlay0_desc9 = "b,0.78393,0.96139,rect,0.06118,0.03440"
-overlay0_desc9_overlay = "../flat/img/B.png"
-overlay0_desc10 = "x,0.78393,0.84741,rect,0.06118,0.03440"
-overlay0_desc10_overlay = "../flat/img/X.png"
-overlay0_desc11 = "y,0.68260,0.90440,rect,0.06118,0.03440"
-overlay0_desc11_overlay = "../flat/img/Y.png"
-
-# Select button
-overlay0_desc12 = "select,0.46,0.96,rect,0.035,0.02"
-overlay0_desc12_overlay = "../flat/img/select_rounded_big.png"
-overlay0_desc12_reach_left = 1.2
-overlay0_desc12_reach_right = 1.6
-overlay0_desc12_reach_y = 1.6
-overlay0_desc12_exclusive = true
-
-# Start button
-overlay0_desc13 = "start,0.54,0.96,rect,0.035,0.02"
-overlay0_desc13_overlay = "../flat/img/start_rounded_big.png"
-overlay0_desc13_reach_right = 1.2
-overlay0_desc13_reach_left = 1.6
-overlay0_desc13_reach_y = 1.6
-overlay0_desc13_exclusive = true
-
-# L button
-overlay0_desc14 = "l,0.1,0.77,rect,0.065,0.0228"
-overlay0_desc14_overlay = "../flat/img/L_smaller.png"
-overlay0_desc14_reach_x = 1.2
-overlay0_desc14_reach_y = 2.0
-overlay0_desc14_exclusive = true
-
-# R button
-overlay0_desc15 = "r,0.9,0.77,rect,0.065,0.02280"
-overlay0_desc15_overlay = "../flat/img/R_smaller.png"
-overlay0_desc15_reach_x = 1.2
-overlay0_desc15_reach_y = 2.0
-overlay0_desc15_exclusive = true
-
-# Combo buttons
-overlay0_desc16 = "x|y,0.68260,0.84741,radial,0.02469,0.01389"
-overlay0_desc17 = "a|b,0.88527,0.96139,radial,0.02469,0.01389"
-overlay0_desc18 = "y|b,0.68260,0.96139,radial,0.02469,0.01389"
-overlay0_desc19 = "x|a,0.88527,0.84741,radial,0.02469,0.01389"
-
-# Menu button
-overlay0_desc20 = "menu_toggle,0.5,0.77,radial,0.035,0.02"
-overlay0_desc20_overlay = "../flat/img/rgui.png"
-overlay0_desc20_reach_x = 1.67
-overlay0_desc20_reach_y = 1.6
-overlay0_desc20_exclusive = true
-
-# Tap stylus + quick screen switch
-overlay0_desc21 = "r2|r3,0.5,0.835,radial,0.035,0.02"
-overlay0_desc21_overlay = "../flat/img/2-button_gba_modified.png"
-
-# Rotate overlay
-overlay0_desc22 = "overlay_next,0.5,0.90,radial,0.035,0.02"
-overlay0_desc22_overlay = "../flat/img/rotate.png"
-overlay0_desc22_next_target = "landscape"
-
-########################################
-## Overlay 1: landscape
-overlay1_descs = 24
-
-# D-Pad
-overlay1_desc0 = "left,0.07188,0.77778,radial,0.04479,0.06852"
-overlay1_desc0_overlay = ../flat/img/dpad-left.png
-overlay1_desc1 = "right,0.17813,0.77778,radial,0.04479,0.06852"
-overlay1_desc1_overlay = ../flat/img/dpad-right.png
-overlay1_desc2 = "up,0.12500,0.68333,radial,0.03854,0.07963"
-overlay1_desc2_overlay = ../flat/img/dpad-up.png
-overlay1_desc3 = "down,0.12500,0.87222,radial,0.03854,0.07963"
-overlay1_desc3_overlay = ../flat/img/dpad-down.png
-
-# D-Pad diagonals
-overlay1_desc4 = "left|up,0.05625,0.65556,rect,0.03021,0.05370"
-overlay1_desc5 = "right|up,0.19375,0.65556,rect,0.03021,0.05370"
-overlay1_desc6 = "left|down,0.05625,0.90000,rect,0.03021,0.05370"
-overlay1_desc7 = "right|down,0.19375,0.90000,rect,0.03021,0.05370"
+overlay0_desc4 = "left|up,0.05625,0.65556,rect,0.03021,0.05370"
+overlay0_desc5 = "right|up,0.19375,0.65556,rect,0.03021,0.05370"
+overlay0_desc6 = "left|down,0.05625,0.90000,rect,0.03021,0.05370"
+overlay0_desc7 = "right|down,0.19375,0.90000,rect,0.03021,0.05370"
 
 # ABXY
-overlay1_desc8 = "a,0.92188,0.75000,radial,0.04167,0.07407"
-overlay1_desc8_overlay = ../flat/img/A.png
-overlay1_desc9 = "b,0.85938,0.86111,radial,0.04167,0.07407"
-overlay1_desc9_overlay = ../flat/img/B.png
-overlay1_desc10 = "x,0.85938,0.63889,radial,0.04167,0.07407"
-overlay1_desc10_overlay = ../flat/img/X.png
-overlay1_desc11 = "y,0.79688,0.75000,radial,0.04167,0.07407"
-overlay1_desc11_overlay = ../flat/img/Y.png
+overlay0_desc8 = "abxy_area,0.85938,0.75,rect,0.102,0.181"
+overlay0_desc8_reach_x = 1.4
+overlay0_desc8_reach_y = 1.4
+overlay0_desc8_range_mod = 1.1
+overlay0_desc8_range_mod_exclusive = true
 
-# Select/Start buttons
-overlay1_desc12 = "select,0.06250,0.28889,rect,0.03958,0.07037"
-overlay1_desc12_overlay = ../flat/img/select_rounded_big.png
-overlay1_desc13 = "start,0.93750,0.28889,rect,0.03958,0.07037"
-overlay1_desc13_overlay = ../flat/img/start_rounded_big.png
+overlay0_desc9 = "a,0.92188,0.75000,radial,0.04167,0.07407"
+overlay0_desc9_overlay = ../flat/img/A.png
+
+overlay0_desc10 = "b,0.85938,0.86111,radial,0.04167,0.07407"
+overlay0_desc10_overlay = ../flat/img/B.png
+
+overlay0_desc11 = "x,0.85938,0.63889,radial,0.04167,0.07407"
+overlay0_desc11_overlay = ../flat/img/X.png
+
+overlay0_desc12 = "y,0.79688,0.75000,radial,0.04167,0.07407"
+overlay0_desc12_overlay = ../flat/img/Y.png
+
+# Select/start
+overlay0_desc13 = "start,0.93750,0.28889,rect,0.03958,0.07037"
+overlay0_desc13_overlay = ../flat/img/start_rounded_big.png
+
+overlay0_desc14 = "select,0.06250,0.28889,rect,0.03958,0.07037"
+overlay0_desc14_overlay = ../flat/img/select_rounded_big.png
 
 # L/R buttons
-overlay1_desc14 = "l,0.02917,0.50556,rect,0.04896,0.05370"
-overlay1_desc14_overlay = ../flat/img/L_smaller.png
-overlay1_desc15 = "r,0.97083,0.50556,rect,0.04896,0.05370"
-overlay1_desc15_overlay = ../flat/img/R_smaller.png
+overlay0_desc15 = "l,0.02917,0.50556,rect,0.04896,0.05370"
+overlay0_desc15_overlay = ../flat/img/L_smaller.png
 
-# Combo buttons
-overlay1_desc16 = "x|y,0.79688,0.63889,radial,0.01389,0.02469"
-overlay1_desc17 = "a|b,0.92188,0.86111,radial,0.01389,0.02469"
-overlay1_desc18 = "y|b,0.79688,0.86111,radial,0.01389,0.02469"
-overlay1_desc19 = "x|a,0.92188,0.63889,radial,0.01389,0.02469"
+overlay0_desc16 = "r,0.97083,0.50556,rect,0.04896,0.05370"
+overlay0_desc16_overlay = ../flat/img/R_smaller.png
 
-# Tap stylus + quick screen switch
-overlay1_desc20 = "r2|r3,0.06250,0.08889,radial,0.02604,0.046296"
-overlay1_desc20_overlay = ../flat/img/2-button_gba_modified.png
+# Menu
+overlay0_desc17 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.046296"
+overlay0_desc17_overlay = ../flat/img/rgui.png
 
-# Menu button
-overlay1_desc21 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.04629"
-overlay1_desc21_overlay = ../flat/img/rgui.png
+# Invisible rotate hotkey
+overlay0_desc18 = "overlay_next,2.5,2.5,radial,0.1,0.1"
+overlay0_desc18_next_target = "portrait"
 
-# Hide overlay
-overlay1_desc22 = "overlay_next,0.80000,0.08889,radial,0.02604,0.04629"
-overlay1_desc22_overlay = ../flat/img/hide.png
-overlay1_desc22_next_target = "hidden"
+overlay0_desc19 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
+overlay0_desc19_overlay = ../flat/img/hide.png
+overlay0_desc19_next_target = "hidden"
 
-# Rotate overlay
-overlay1_desc23 = "overlay_next,0.20000,0.08889,radial,0.02604,0.04629"
-overlay1_desc23_overlay = ../flat/img/rotate.png
-overlay1_desc23_next_target = "portrait"
+# ABXY combo buttons
+overlay0_desc20 = "x|y,0.82188,0.68333,radial,0.01389,0.02469"
+overlay0_desc21 = "x|y,0.83438,0.70556,radial,0.01389,0.02469"
 
-########################################
+overlay0_desc22 = "a|b,0.88438,0.79444,radial,0.01389,0.02469"
+overlay0_desc23 = "a|b,0.89688,0.81667,radial,0.01389,0.02469"
+
+overlay0_desc24 = "y|b,0.82188,0.81667,radial,0.01389,0.02469"
+overlay0_desc25 = "y|b,0.83438,0.79444,radial,0.01389,0.02469"
+
+overlay0_desc26 = "x|a,0.88438,0.70556,radial,0.01389,0.02469"
+overlay0_desc27 = "x|a,0.89688,0.68333,radial,0.01389,0.02469"
+
+# Switch screens
+overlay0_desc28 = "r2|r3,0.06250,0.08889,radial,0.02604,0.046296"
+overlay0_desc28_overlay = ../flat/img/2-button_gba_modified.png
+
+# Fast forward
+overlay0_desc29 = "toggle_fast_forward,0.20000,0.08889,radial,0.02604,0.046296"
+overlay0_desc29_overlay = ../flat/img/fast_forward.png
+
+
+## Overlay 1: portrait
+overlay1_descs = 29
+
+# D-Pad
+overlay1_desc0 = "down,0.21606,0.95333,radial,0.06118,0.04247"
+overlay1_desc0_overlay = dpad-down.png
+overlay1_desc1 = "left,0.12906,0.90440,radial,0.07552,0.03440"
+overlay1_desc1_overlay = dpad-left.png
+overlay1_desc2 = "right,0.30305,0.90440,radial,0.07552,0.03440"
+overlay1_desc2_overlay = dpad-right.png
+overlay1_desc3 = "up,0.21606,0.85548,radial,0.06118,0.04247"
+overlay1_desc3_overlay = dpad-up.png
+overlay1_desc4 = "down|left,0.1,0.968,rect,0.053,0.027"
+overlay1_desc5 = "down|right,0.333,0.968,rect,0.053,0.027"
+overlay1_desc6 = "up|left,0.1,0.842,rect,0.053,0.027"
+overlay1_desc7 = "up|right,0.333,0.842,rect,0.053,0.027"
+
+# ABXY
+overlay1_desc8 = "abxy_area,0.78393,0.90440,rect,0.159259,0.089583"
+overlay1_desc8_reach_x = 1.4
+overlay1_desc8_reach_y = 1.4
+overlay1_desc8_range_mod = 1.1
+overlay1_desc8_range_mod_exclusive = true
+
+overlay1_desc9 = "a,0.88527,0.90440,radial,0.06118,0.03440"
+overlay1_desc9_overlay = A.png
+
+overlay1_desc10 = "b,0.78393,0.96139,radial,0.06118,0.03440"
+overlay1_desc10_overlay = B.png
+
+overlay1_desc11 = "x,0.78393,0.84741,radial,0.06118,0.03440"
+overlay1_desc11_overlay = X.png
+
+overlay1_desc12 = "y,0.68260,0.90440,radial,0.06118,0.03440"
+overlay1_desc12_overlay = Y.png
+
+# Select/start
+overlay1_desc13 = "select,0.46,0.96,rect,0.035,0.02"
+overlay1_desc13_overlay = select_rounded_big.png
+overlay1_desc13_reach_left = 1.2
+overlay1_desc13_reach_right = 1.6
+overlay1_desc13_reach_y = 1.6
+overlay1_desc13_exclusive = true
+
+overlay1_desc14 = "start,0.54,0.96,rect,0.035,0.02"
+overlay1_desc14_overlay = start_rounded_big.png
+overlay1_desc14_reach_right = 1.2
+overlay1_desc14_reach_left = 1.6
+overlay1_desc14_reach_y = 1.6
+overlay1_desc14_exclusive = true
+
+# L/R buttons
+overlay1_desc15 = "l,0.1,0.77,rect,0.065,0.02280"
+overlay1_desc15_overlay = "../flat/img/L_smaller.png"
+overlay1_desc15_reach_x = 1.2
+overlay1_desc15_reach_y = 2.0
+overlay1_desc15_exclusive = true
+
+overlay1_desc16 = "r,0.9,0.77,rect,0.065,0.02280"
+overlay1_desc16_overlay = "../flat/img/R_smaller.png"
+overlay1_desc16_reach_x = 1.2
+overlay1_desc16_reach_y = 2.0
+overlay1_desc16_exclusive = true
+
+# Menu
+overlay1_desc17 = "menu_toggle,0.5,0.84440,radial,0.035,0.02"
+overlay1_desc17_overlay = "../flat/img/rgui.png"
+overlay1_desc17_reach_x = 1.67
+overlay1_desc17_reach_y = 1.6
+overlay1_desc17_exclusive = true
+
+# Invisible rotate hotkey
+overlay1_desc18 = "overlay_next,2.5,2.5,radial,0.1,0.1"
+overlay1_desc18_next_target = "landscape"
+
+# ABXY combo buttons
+overlay1_desc19 = "x|y,0.716,0.865,radial,0.02469,0.01389"
+overlay1_desc20 = "x|y,0.733,0.876,radial,0.02469,0.01389"
+
+overlay1_desc21 = "a|b,0.834,0.933,radial,0.02469,0.01389"
+overlay1_desc22 = "a|b,0.854,0.945,radial,0.02469,0.01389"
+
+overlay1_desc23 = "y|b,0.733,0.933,radial,0.02469,0.01389"
+overlay1_desc24 = "y|b,0.716,0.945,radial,0.02469,0.01389"
+
+overlay1_desc25 = "x|a,0.854,0.865,radial,0.02469,0.01389"
+overlay1_desc26 = "x|a,0.834,0.876,radial,0.02469,0.01389"
+
+# Switch screens
+overlay1_desc27 = "r2|r3,0.46,0.90,radial,0.035,0.02"
+overlay1_desc27_overlay = 2-button_gba_modified.png
+
+# Fast forward
+overlay1_desc28 = "toggle_fast_forward,0.54,0.90,radial,0.035,0.02"
+overlay1_desc28_overlay = fast_forward.png
+
+
 ## Overlay 2: hidden
 overlay2_descs = 1
 
-# Show overlay
-overlay2_desc0 = "overlay_next,0.80000,0.08889,radial,0.02604,0.04629"
-overlay2_desc0_next_target = "portrait"
+# Show hotkey
+overlay2_desc0 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
+overlay2_desc0_next_target = "landscape"
 overlay2_desc0_overlay = "../flat/img/show.png"
 overlay2_desc0_reach_x = 1.6
 overlay2_desc0_reach_y = 1.6

--- a/gamepads/Named_Overlays/Nintendo - Nintendo DSi.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo DSi.cfg
@@ -1,20 +1,20 @@
 overlays = 3
 
-overlay0_name = "landscape"
+overlay0_name = "portrait"
 overlay0_full_screen = true
 overlay0_normalized = true
-overlay0_aspect_ratio = 1.77777778
+overlay0_aspect_ratio = 0.5623
 overlay0_block_x_separation = false
-overlay0_block_y_separation = false
+overlay0_block_y_separation = true
 overlay0_range_mod = 1.5
 overlay0_alpha_mod = 2.0
 
-overlay1_name = "portrait"
+overlay1_name = "landscape"
 overlay1_full_screen = true
 overlay1_normalized = true
-overlay1_aspect_ratio = 0.56236559139784946237
+overlay1_aspect_ratio = 1.77777778
 overlay1_block_x_separation = false
-overlay1_block_y_separation = true
+overlay1_block_y_separation = false
 overlay1_range_mod = 1.5
 overlay1_alpha_mod = 2.0
 
@@ -27,192 +27,161 @@ overlay2_block_y_separation = false
 overlay2_range_mod = 1.5
 overlay2_alpha_mod = 2.0
 
-
-# Overlay 0 - landscape
-overlay0_descs = 31
-
-overlay0_desc0 = "left,0.07188,0.77778,radial,0.04479,0.06852"
-overlay0_desc0_overlay = ../flat/img/dpad-left.png
-overlay0_desc1 = "right,0.17813,0.77778,radial,0.04479,0.06852"
-overlay0_desc1_overlay = ../flat/img/dpad-right.png
-overlay0_desc2 = "up,0.12500,0.68333,radial,0.03854,0.07963"
-overlay0_desc2_overlay = ../flat/img/dpad-up.png
-overlay0_desc3 = "down,0.12500,0.87222,radial,0.03854,0.07963"
-overlay0_desc3_overlay = ../flat/img/dpad-down.png
-overlay0_desc4 = "left|up,0.05625,0.65556,rect,0.03021,0.05370"
-overlay0_desc5 = "right|up,0.19375,0.65556,rect,0.03021,0.05370"
-overlay0_desc6 = "left|down,0.05625,0.90000,rect,0.03021,0.05370"
-overlay0_desc7 = "right|down,0.19375,0.90000,rect,0.03021,0.05370"
-
-overlay0_desc8 = "a,0.92188,0.75000,radial,0.04167,0.07407"
-overlay0_desc8_overlay = ../flat/img/A.png
-overlay0_desc9 = "b,0.85938,0.86111,radial,0.04167,0.07407"
-overlay0_desc9_overlay = ../flat/img/B.png
-overlay0_desc10 = "x,0.85938,0.63889,radial,0.04167,0.07407"
-overlay0_desc10_overlay = ../flat/img/X.png
-overlay0_desc11 = "y,0.79688,0.75000,radial,0.04167,0.07407"
-overlay0_desc11_overlay = ../flat/img/Y.png
-
-overlay0_desc12 = "start,0.93750,0.28889,rect,0.03958,0.07037"
-overlay0_desc12_overlay = ../flat/img/start_rounded_big.png
-overlay0_desc13 = "select,0.06250,0.28889,rect,0.03958,0.07037"
-overlay0_desc13_overlay = ../flat/img/select_rounded_big.png
-
-overlay0_desc14 = "l,0.02917,0.50556,rect,0.04896,0.05370"
-overlay0_desc14_overlay = ../flat/img/L_smaller.png
-overlay0_desc15 = "nul,1.76458,0.94815,rect,0.03229,0.08704"
-#overlay0_desc15_overlay = ../flat/img/L_down_smaller_gba.png
-overlay0_desc16 = "r,0.97083,0.50556,rect,0.04896,0.05370"
-overlay0_desc16_overlay = ../flat/img/R_smaller.png
-
-overlay0_desc17 = "nul,1.64688,0.94815,rect,0.05416,0.09259"
-#overlay0_desc17_overlay = ../flat/img/L_and_R_down.png
-
-overlay0_desc18 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.046296"
-overlay0_desc18_overlay = ../flat/img/rgui.png
-
-# invisible rotate button
-overlay0_desc19 = "overlay_next,2.5,2.5,radial,0.1,0.1"
-overlay0_desc19_next_target = "portrait"
-
-overlay0_desc20 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
-overlay0_desc20_overlay = ../flat/img/hide.png
-overlay0_desc20_next_target = "hidden"
-
-# Combo buttons
-overlay0_desc21 = "x|y,0.82188,0.68333,radial,0.01389,0.02469"
-overlay0_desc22 = "x|y,0.83438,0.70556,radial,0.01389,0.02469"
-
-overlay0_desc23 = "a|b,0.88438,0.79444,radial,0.01389,0.02469"
-overlay0_desc24 = "a|b,0.89688,0.81667,radial,0.01389,0.02469"
-
-overlay0_desc25 = "y|b,0.82188,0.81667,radial,0.01389,0.02469"
-overlay0_desc26 = "y|b,0.83438,0.79444,radial,0.01389,0.02469"
-
-overlay0_desc27 = "x|a,0.88438,0.70556,radial,0.01389,0.02469"
-overlay0_desc28 = "x|a,0.89688,0.68333,radial,0.01389,0.02469"
-
-overlay0_desc29 = "r2|r3,0.06250,0.08889,radial,0.02604,0.046296"
-overlay0_desc29_overlay = ../flat/img/2-button_gba_modified.png
-
-overlay0_desc30 = "toggle_fast_forward,0.20000,0.08889,radial,0.02604,0.046296"
-overlay0_desc30_overlay = ../flat/img/fast_forward.png
-
-overlay0_desc30 = "toggle_fast_forward,0.20000,0.08889,radial,0.02604,0.046296"
-overlay0_desc30_overlay = ../flat/png/fast_forward.png
-
-
-## Overlay 1: portrait
-overlay1_descs = 33
+########################################
+## Overlay 0: portrait
+overlay0_descs = 23
 
 # D-Pad
+overlay0_desc0 = "down,0.21606,0.95333,rect,0.06118,0.04247"
+overlay0_desc0_overlay = "../flat/img/dpad-down.png"
+overlay0_desc1 = "left,0.12906,0.90440,rect,0.07552,0.03440"
+overlay0_desc1_overlay = "../flat/img/dpad-left.png"
+overlay0_desc2 = "right,0.3030,0.90440,rect,0.07552,0.03440"
+overlay0_desc2_overlay = "../flat/img/dpad-right.png"
+overlay0_desc3 = "up,0.21606,0.85548,rect,0.06118,0.04247"
+overlay0_desc3_overlay = "../flat/img/dpad-up.png"
 
-overlay1_desc0 = "down,0.21606118546845123896,0.95333333333333334814,rect,0.06118546845124282763,0.04247311827956989222"
-overlay1_desc0_overlay = "../flat/img/dpad-down.png"
-
-overlay1_desc1 = "left,0.12906309751434033584,0.90440860215053762605,rect,0.07552581261950286340,0.03440860215053763438"
-overlay1_desc1_overlay = "../flat/img/dpad-left.png"
-
-overlay1_desc2 = "right,0.30305927342256211432,0.90440860215053762605,rect,0.07552581261950286340,0.03440860215053763438"
-overlay1_desc2_overlay = "../flat/img/dpad-right.png"
-
-overlay1_desc3 = "up,0.21606118546845123896,0.85548387096774190397,rect,0.06118546845124282763,0.04247311827956989222"
-overlay1_desc3_overlay = "../flat/img/dpad-up.png"
-
-overlay1_desc4 = "down,0.21606118546845123896,0.97456989247311829772,rect,0.06118546845124282763,0.02123655913978494611"
-overlay1_desc5 = "left,0.09130019120458890414,0.90440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
-overlay1_desc6 = "right,0.34082217973231360153,0.93440860215053762605,rect,0.03776290630975143170,0.03440860215053763438"
-overlay1_desc7 = "up,0.21606118546845123896,0.83424731182795695439,rect,0.06118546845124282763,0.02123655913978494611"
-overlay1_desc8 = "down|left,0.09655831739961759363,0.97161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
-overlay1_desc9 = "down|right,0.33556405353728491203,0.97161290322580649459,rect,0.04302103250478011426,0.02419354838709677352"
-overlay1_desc10 = "up|left,0.09655831739961759363,0.83720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
-overlay1_desc11 = "up|right,0.33556405353728491203,0.83720430107526886854,rect,0.04302103250478011426,0.02419354838709677352"
+# D-Pad diagonals
+overlay0_desc4 = "down|left,0.09655,0.97161,rect,0.04302,0.02419"
+overlay0_desc5 = "down|right,0.33556,0.97161,rect,0.04302,0.02419"
+overlay0_desc6 = "up|left,0.09655,0.83720,rect,0.04302,0.02419"
+overlay0_desc7 = "up|right,0.33556,0.83720,rect,0.04302,0.02419"
 
 # ABXY
-overlay1_desc12 = "abxy_area,0.78393881453154878880,0.90440860215053762605,rect,0.159259,0.089583"
-overlay1_desc12_reach_x = 1.4
-overlay1_desc12_reach_y = 1.4
-overlay1_desc12_range_mod = 1.1
-overlay1_desc12_range_mod_exclusive = true
+overlay0_desc8 = "a,0.88527,0.90440,rect,0.06118,0.03440"
+overlay0_desc8_overlay = "../flat/img/A.png"
+overlay0_desc9 = "b,0.78393,0.96139,rect,0.06118,0.03440"
+overlay0_desc9_overlay = "../flat/img/B.png"
+overlay0_desc10 = "x,0.78393,0.84741,rect,0.06118,0.03440"
+overlay0_desc10_overlay = "../flat/img/X.png"
+overlay0_desc11 = "y,0.68260,0.90440,rect,0.06118,0.03440"
+overlay0_desc11_overlay = "../flat/img/Y.png"
 
-overlay1_desc13 = "a,0.88527724665391971381,0.90440860215053762605,rect,0.06118546845124282763,0.03440860215053763438"
-overlay1_desc13_overlay = "../flat/img/A.png"
-overlay1_desc13_reach_x = 0
+# Select button
+overlay0_desc12 = "select,0.46,0.96,rect,0.035,0.02"
+overlay0_desc12_overlay = "../flat/img/select_rounded_big.png"
+overlay0_desc12_reach_left = 1.2
+overlay0_desc12_reach_right = 1.6
+overlay0_desc12_reach_y = 1.6
+overlay0_desc12_exclusive = true
 
-overlay1_desc14 = "b,0.78393881453154878880,0.96139784946236559904,rect,0.06118546845124282763,0.03440860215053763438"
-overlay1_desc14_overlay = "../flat/img/B.png"
-overlay1_desc14_reach_x = 0
+# Start button
+overlay0_desc13 = "start,0.54,0.96,rect,0.035,0.02"
+overlay0_desc13_overlay = "../flat/img/start_rounded_big.png"
+overlay0_desc13_reach_right = 1.2
+overlay0_desc13_reach_left = 1.6
+overlay0_desc13_reach_y = 1.6
+overlay0_desc13_exclusive = true
 
-overlay1_desc15 = "x,0.78393881453154878880,0.84741935483870965307,rect,0.06118546845124282763,0.03440860215053763438"
-overlay1_desc15_overlay = "../flat/img/X.png"
-overlay1_desc15_reach_x = 0
+# L button
+overlay0_desc14 = "l,0.1,0.77,rect,0.065,0.0228"
+overlay0_desc14_overlay = "../flat/img/L_smaller.png"
+overlay0_desc14_reach_x = 1.2
+overlay0_desc14_reach_y = 2.0
+overlay0_desc14_exclusive = true
 
-overlay1_desc16 = "y,0.68260038240917786379,0.90440860215053762605,rect,0.06118546845124282763,0.03440860215053763438"
-overlay1_desc16_overlay = "../flat/img/Y.png"
-overlay1_desc16_reach_x = 0
-
-# Select/start
-overlay1_desc17 = "select,0.465,0.96,rect,0.035,0.02"
-overlay1_desc17_overlay = "../flat/img/select_rounded_big.png"
-overlay1_desc17_reach_left = 1.2
-overlay1_desc17_reach_right = 1.6
-overlay1_desc17_reach_y = 1.6
-overlay1_desc17_exclusive = true
-
-overlay1_desc18 = "start,0.535,0.96,rect,0.035,0.02"
-overlay1_desc18_overlay = "../flat/img/start_rounded_big.png"
-overlay1_desc18_reach_right = 1.2
-overlay1_desc18_reach_left = 1.6
-overlay1_desc18_reach_y = 1.6
-overlay1_desc18_exclusive = true
-
-# L/R buttons
-overlay1_desc19 = "l,0.1,0.77,rect,0.065,0.02280645161290322578"
-overlay1_desc19_overlay = "../flat/img/L_smaller.png"
-overlay1_desc19_reach_x = 1.2
-overlay1_desc19_reach_y = 2.0
-overlay1_desc19_exclusive = true
-
-overlay1_desc20 = "r,0.9,0.77,rect,0.065,0.02280645161290322578"
-overlay1_desc20_overlay = "../flat/img/R_smaller.png"
-overlay1_desc20_reach_x = 1.2
-overlay1_desc20_reach_y = 2.0
-overlay1_desc20_exclusive = true
-
-# Hotkeys
-overlay1_desc21 = "menu_toggle,0.5,0.84440860215053762605,radial,0.035,0.02"
-overlay1_desc21_overlay = "../flat/img/rgui.png"
-overlay1_desc21_reach_x = 1.67
-overlay1_desc21_reach_y = 1.6
-overlay1_desc21_exclusive = true
-
-# Invisible rotate hotkey
-overlay1_desc22 = "overlay_next,2.5,2.5,radial,0.1,0.1"
-overlay1_desc22_next_target = "landscape"
+# R button
+overlay0_desc15 = "r,0.9,0.77,rect,0.065,0.02280"
+overlay0_desc15_overlay = "../flat/img/R_smaller.png"
+overlay0_desc15_reach_x = 1.2
+overlay0_desc15_reach_y = 2.0
+overlay0_desc15_exclusive = true
 
 # Combo buttons
-overlay1_desc23 = "x|y,0.719336,0.796733,radial,0.02469,0.01389"
-overlay1_desc24 = "x|y,0.744591,0.814428,radial,0.02469,0.01389"
-overlay1_desc25 = "a|b,0.826904,0.857957,radial,0.02469,0.01389"
-overlay1_desc26 = "a|b,0.847057,0.875652,radial,0.02469,0.01389"
-overlay1_desc27 = "y|b,0.722737,0.871116,radial,0.02469,0.01389"
-overlay1_desc28 = "y|b,0.742891,0.857957,radial,0.02469,0.01389"
-overlay1_desc29 = "x|a,0.828605,0.811027,radial,0.02469,0.01389"
-overlay1_desc30 = "x|a,0.847908,0.796733,radial,0.02469,0.01389"
+overlay0_desc16 = "x|y,0.68260,0.84741,radial,0.02469,0.01389"
+overlay0_desc17 = "a|b,0.88527,0.96139,radial,0.02469,0.01389"
+overlay0_desc18 = "y|b,0.68260,0.96139,radial,0.02469,0.01389"
+overlay0_desc19 = "x|a,0.88527,0.84741,radial,0.02469,0.01389"
 
-overlay1_desc31 = "r2|r3,0.465,0.90,radial,0.035,0.02"
-overlay1_desc31_overlay = "../flat/img/2-button_gba_modified.png"
+# Menu button
+overlay0_desc20 = "menu_toggle,0.5,0.77,radial,0.035,0.02"
+overlay0_desc20_overlay = "../flat/img/rgui.png"
+overlay0_desc20_reach_x = 1.67
+overlay0_desc20_reach_y = 1.6
+overlay0_desc20_exclusive = true
 
-overlay1_desc32 = "toggle_fast_forward,0.535,0.90,radial,0.035,0.02"
-overlay1_desc32_overlay = "../flat/img/fast_forward.png"
+# Tap stylus + quick screen switch
+overlay0_desc21 = "r2|r3,0.5,0.835,radial,0.035,0.02"
+overlay0_desc21_overlay = "../flat/img/2-button_gba_modified.png"
 
+# Rotate overlay
+overlay0_desc22 = "overlay_next,0.5,0.90,radial,0.035,0.02"
+overlay0_desc22_overlay = "../flat/img/rotate.png"
+overlay0_desc22_next_target = "landscape"
 
+########################################
+## Overlay 1: landscape
+overlay1_descs = 24
+
+# D-Pad
+overlay1_desc0 = "left,0.07188,0.77778,radial,0.04479,0.06852"
+overlay1_desc0_overlay = ../flat/img/dpad-left.png
+overlay1_desc1 = "right,0.17813,0.77778,radial,0.04479,0.06852"
+overlay1_desc1_overlay = ../flat/img/dpad-right.png
+overlay1_desc2 = "up,0.12500,0.68333,radial,0.03854,0.07963"
+overlay1_desc2_overlay = ../flat/img/dpad-up.png
+overlay1_desc3 = "down,0.12500,0.87222,radial,0.03854,0.07963"
+overlay1_desc3_overlay = ../flat/img/dpad-down.png
+
+# D-Pad diagonals
+overlay1_desc4 = "left|up,0.05625,0.65556,rect,0.03021,0.05370"
+overlay1_desc5 = "right|up,0.19375,0.65556,rect,0.03021,0.05370"
+overlay1_desc6 = "left|down,0.05625,0.90000,rect,0.03021,0.05370"
+overlay1_desc7 = "right|down,0.19375,0.90000,rect,0.03021,0.05370"
+
+# ABXY
+overlay1_desc8 = "a,0.92188,0.75000,radial,0.04167,0.07407"
+overlay1_desc8_overlay = ../flat/img/A.png
+overlay1_desc9 = "b,0.85938,0.86111,radial,0.04167,0.07407"
+overlay1_desc9_overlay = ../flat/img/B.png
+overlay1_desc10 = "x,0.85938,0.63889,radial,0.04167,0.07407"
+overlay1_desc10_overlay = ../flat/img/X.png
+overlay1_desc11 = "y,0.79688,0.75000,radial,0.04167,0.07407"
+overlay1_desc11_overlay = ../flat/img/Y.png
+
+# Select/Start buttons
+overlay1_desc12 = "select,0.06250,0.28889,rect,0.03958,0.07037"
+overlay1_desc12_overlay = ../flat/img/select_rounded_big.png
+overlay1_desc13 = "start,0.93750,0.28889,rect,0.03958,0.07037"
+overlay1_desc13_overlay = ../flat/img/start_rounded_big.png
+
+# L/R buttons
+overlay1_desc14 = "l,0.02917,0.50556,rect,0.04896,0.05370"
+overlay1_desc14_overlay = ../flat/img/L_smaller.png
+overlay1_desc15 = "r,0.97083,0.50556,rect,0.04896,0.05370"
+overlay1_desc15_overlay = ../flat/img/R_smaller.png
+
+# Combo buttons
+overlay1_desc16 = "x|y,0.79688,0.63889,radial,0.01389,0.02469"
+overlay1_desc17 = "a|b,0.92188,0.86111,radial,0.01389,0.02469"
+overlay1_desc18 = "y|b,0.79688,0.86111,radial,0.01389,0.02469"
+overlay1_desc19 = "x|a,0.92188,0.63889,radial,0.01389,0.02469"
+
+# Tap stylus + quick screen switch
+overlay1_desc20 = "r2|r3,0.06250,0.08889,radial,0.02604,0.046296"
+overlay1_desc20_overlay = ../flat/img/2-button_gba_modified.png
+
+# Menu button
+overlay1_desc21 = "menu_toggle,0.93750,0.08889,radial,0.02604,0.04629"
+overlay1_desc21_overlay = ../flat/img/rgui.png
+
+# Hide overlay
+overlay1_desc22 = "overlay_next,0.80000,0.08889,radial,0.02604,0.04629"
+overlay1_desc22_overlay = ../flat/img/hide.png
+overlay1_desc22_next_target = "hidden"
+
+# Rotate overlay
+overlay1_desc23 = "overlay_next,0.20000,0.08889,radial,0.02604,0.04629"
+overlay1_desc23_overlay = ../flat/img/rotate.png
+overlay1_desc23_next_target = "portrait"
+
+########################################
 ## Overlay 2: hidden
 overlay2_descs = 1
 
-# Show hotkey
-overlay2_desc0 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
-overlay2_desc0_next_target = "landscape"
+# Show overlay
+overlay2_desc0 = "overlay_next,0.80000,0.08889,radial,0.02604,0.04629"
+overlay2_desc0_next_target = "portrait"
 overlay2_desc0_overlay = "../flat/img/show.png"
 overlay2_desc0_reach_x = 1.6
 overlay2_desc0_reach_y = 1.6


### PR DESCRIPTION
Rewrite of DS / DSi named overlays.
* Removed all the invisible / disabled buttons that didn't do anything (next_overlay, l|r).
* Removed duplicates (x|y).
* Replaced 'fast forward' button with 'next overlay' (can now access portrait and hidden layouts).
* Reduced lengthy decimal places to 5 max.
* Swapped overlay order so portrait is first, landscape second.