### PR TITLE
fix dpad on sideways wiimote

### DIFF
--- a/gamepads/Named_Overlays/Nintendo - GameCube.cfg
+++ b/gamepads/Named_Overlays/Nintendo - GameCube.cfg
@@ -87,6 +87,7 @@ overlay0_desc21_overlay = ../flat/img/gcn-thumbstick.png
 overlay0_desc21_range_mod = 30.0
 overlay0_desc21_saturate_pct = 0.65
 overlay0_desc21_movable = true
+overlay0_desc21_range_mod_exclusive = true
 
 # Z-trigger
 overlay0_desc22 = "r,0.92750,0.24815,rect,0.0708,0.045"
@@ -100,6 +101,7 @@ overlay0_desc24_overlay = ../flat/img/C.png
 overlay0_desc24_range_mod = 30.0
 overlay0_desc24_saturate_pct = 0.65
 overlay0_desc24_movable = true
+overlay0_desc24_range_mod_exclusive = true
 
 
 # Overlay 1 - hidden
@@ -151,6 +153,7 @@ overlay2_desc12_overlay = ../flat/img/gcn-thumbstick.png
 overlay2_desc12_range_mod = 30.0
 overlay2_desc12_saturate_pct = 0.65
 overlay2_desc12_movable = true
+overlay2_desc12_range_mod_exclusive = true
 
 # C-stick
 overlay2_desc13 = "nul,0.850,0.92,radial,0.11388,0.06406"
@@ -160,6 +163,7 @@ overlay2_desc14_overlay = ../flat/img/C.png
 overlay2_desc14_range_mod = 30.0
 overlay2_desc14_saturate_pct = 0.65
 overlay2_desc14_movable = true
+overlay2_desc14_range_mod_exclusive = true
 
 # analog L, R
 overlay2_desc15 = "l3,0.23125,0.58889,rect,0.14259,0.039"

--- a/gamepads/Named_Overlays/Nintendo - Nintendo 3DS.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo 3DS.cfg
@@ -70,8 +70,8 @@ overlay0_desc17_overlay = ../flat/img/ZR.png
 
 overlay0_desc18 = "menu_toggle,0.5,0.93,radial,0.02604,0.046296"
 overlay0_desc18_overlay = ../flat/img/rgui.png
-overlay0_desc19 = "overlay_next,0.65000,0.08889,radial,0.02604,0.046296"
-overlay0_desc19_overlay = ../flat/img/rotate.png
+overlay0_desc19 = "overlay_next,2.65000,2.08889,radial,0.02604,0.046296"
+#overlay0_desc19_overlay = ../flat/img/rotate.png
 overlay0_desc19_next_target = "portrait"
 
 overlay0_desc20 = "nul,2.35000,2.08889,radial,0.02604,0.046296"

--- a/gamepads/Named_Overlays/Nintendo - Nintendo 3DS.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo 3DS.cfg
@@ -70,8 +70,8 @@ overlay0_desc17_overlay = ../flat/img/ZR.png
 
 overlay0_desc18 = "menu_toggle,0.5,0.93,radial,0.02604,0.046296"
 overlay0_desc18_overlay = ../flat/img/rgui.png
-overlay0_desc19 = "overlay_next,2.65000,2.08889,radial,0.02604,0.046296"
-#overlay0_desc19_overlay = ../flat/img/rotate.png
+overlay0_desc19 = "overlay_next,0.65000,0.08889,radial,0.02604,0.046296"
+overlay0_desc19_overlay = ../flat/img/rotate.png
 overlay0_desc19_next_target = "portrait"
 
 overlay0_desc20 = "nul,2.35000,2.08889,radial,0.02604,0.046296"
@@ -103,6 +103,7 @@ overlay0_desc31_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay0_desc31_range_mod = 30.0
 overlay0_desc31_saturate_pct = 0.65
 overlay0_desc31_movable = true
+overlay0_desc31_range_mod_exclusive = true
 
 # C-stick
 overlay0_desc32 = "nul,0.93,0.35,radial,0.06406,0.11388"
@@ -112,6 +113,7 @@ overlay0_desc33_overlay = ../flat/img/C.png
 overlay0_desc33_range_mod = 30.0
 overlay0_desc33_saturate_pct = 0.65
 overlay0_desc33_movable = true
+overlay0_desc33_range_mod_exclusive = true
 
 overlay0_desc34 = "toggle_fast_forward,0.20000,0.08889,radial,0.02604,0.046296"
 overlay0_desc34_overlay = ../flat/img/fast_forward.png
@@ -201,7 +203,6 @@ overlay2_desc19 = "menu_toggle,0.5,0.77,radial,0.03824091778202676900,0.02150537
 overlay2_desc19_overlay = "../flat/img/rgui.png"
 overlay2_desc19_reach_x = 1.67
 overlay2_desc19_reach_y = 1.6
-overlay2_desc19_exclusive = true
 
 # Invisible rotate hotkey
 overlay2_desc20 = "overlay_next,2.5,2.0,radial,0.03,0.02"
@@ -225,6 +226,7 @@ overlay2_desc30_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc30_range_mod = 30.0
 overlay2_desc30_saturate_pct = 0.65
 overlay2_desc30_movable = true
+overlay2_desc30_range_mod_exclusive = true
 
 # C-stick
 overlay2_desc31 = "nul,0.88,0.625,radial,0.11388,0.06406"
@@ -234,6 +236,7 @@ overlay2_desc32_overlay = ../flat/img/C.png
 overlay2_desc32_range_mod = 30.0
 overlay2_desc32_saturate_pct = 0.65
 overlay2_desc32_movable = true
+overlay2_desc32_range_mod_exclusive = true
 
 ## Overlay 6: hidden
 overlay1_descs = 1

--- a/gamepads/Named_Overlays/Nintendo - Nintendo 64.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo 64.cfg
@@ -88,7 +88,7 @@ overlay0_desc27 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay0_desc27_overlay = ../flat/img/rgui.png
 
 overlay0_desc28 = "overlay_next,2.65000,2.08889,radial,0.02604,0.046296"
-overlay0_desc28_overlay = ../flat/img/rotate.png
+#overlay0_desc28_overlay = ../flat/img/rotate.png
 overlay0_desc28_next_target = "portrait_analog"
 
 overlay0_desc29 = "nul,2.35000,2.08889,radial,0.02604,0.046296"

--- a/gamepads/Named_Overlays/Nintendo - Nintendo 64.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo 64.cfg
@@ -104,6 +104,7 @@ overlay0_desc32_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay0_desc32_range_mod = 30.0
 overlay0_desc32_saturate_pct = 0.65
 overlay0_desc32_movable = true
+overlay0_desc32_range_mod_exclusive = true
 
 # Z-trigger
 overlay0_desc33 = "l2,0.68750,0.94815,rect,0.05208,0.09259"
@@ -133,6 +134,7 @@ overlay2_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc1_range_mod = 30.0
 overlay2_desc1_saturate_pct = 0.65
 overlay2_desc1_movable = true
+overlay2_desc1_range_mod_exclusive = true
 
 # A, B
 overlay2_desc2 = "b,0.67778,0.92083,radial,0.08148,0.04583"

--- a/gamepads/Named_Overlays/Nintendo - Nintendo 64DD.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo 64DD.cfg
@@ -91,7 +91,7 @@ overlay0_desc28 = "overlay_next,2.65000,2.08889,radial,0.02604,0.046296"
 overlay0_desc28_overlay = ../flat/img/rotate.png
 overlay0_desc28_next_target = "portrait_analog"
 
-overlay0_desc29 = "nul,2.35000,0.08889,radial,0.02604,0.046296"
+overlay0_desc29 = "nul,2.35000,2.08889,radial,0.02604,0.046296"
 
 overlay0_desc30 = "overlay_next,0.35000,0.08889,radial,0.02604,0.046296"
 overlay0_desc30_overlay = ../flat/img/hide.png
@@ -104,6 +104,7 @@ overlay0_desc32_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay0_desc32_range_mod = 30.0
 overlay0_desc32_saturate_pct = 0.65
 overlay0_desc32_movable = true
+overlay0_desc32_range_mod_exclusive = true
 
 # Z-trigger
 overlay0_desc33 = "l2,0.68750,0.94815,rect,0.05208,0.09259"
@@ -111,6 +112,7 @@ overlay0_desc33_overlay = ../flat/img/Z_down.png
 
 overlay0_desc34 = "toggle_fast_forward,0.65000,0.08889,radial,0.02604,0.046296"
 overlay0_desc34_overlay = ../flat/img/fast_forward.png
+
 
 # Overlay 1 - hidden landscape_d-pad
 
@@ -132,6 +134,7 @@ overlay2_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc1_range_mod = 30.0
 overlay2_desc1_saturate_pct = 0.65
 overlay2_desc1_movable = true
+overlay2_desc1_range_mod_exclusive = true
 
 # A, B
 overlay2_desc2 = "b,0.67778,0.92083,radial,0.08148,0.04583"

--- a/gamepads/Named_Overlays/Nintendo - Nintendo 64DD.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Nintendo 64DD.cfg
@@ -88,7 +88,7 @@ overlay0_desc27 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay0_desc27_overlay = ../flat/img/rgui.png
 
 overlay0_desc28 = "overlay_next,2.65000,2.08889,radial,0.02604,0.046296"
-overlay0_desc28_overlay = ../flat/img/rotate.png
+#overlay0_desc28_overlay = ../flat/img/rotate.png
 overlay0_desc28_next_target = "portrait_analog"
 
 overlay0_desc29 = "nul,2.35000,2.08889,radial,0.02604,0.046296"

--- a/gamepads/Named_Overlays/Nintendo - Wii (Digital).cfg
+++ b/gamepads/Named_Overlays/Nintendo - Wii (Digital).cfg
@@ -165,6 +165,7 @@ overlay0_desc21_overlay = ../flat/img/3d_rotate.png
 overlay0_desc21_range_mod = 30.0
 overlay0_desc21_saturate_pct = 0.65
 overlay0_desc21_movable = true
+overlay0_desc21_range_mod_exclusive = true
 
 # plus
 overlay0_desc22 = "start,0.9575,0.44815,rect,0.02,0.035"
@@ -178,6 +179,7 @@ overlay0_desc24_overlay = ../flat/img/finger.png
 overlay0_desc24_range_mod = 30.0
 overlay0_desc24_saturate_pct = 0.65
 overlay0_desc24_movable = true
+overlay0_desc24_range_mod_exclusive = true
 
 overlay0_desc25 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
 overlay0_desc25_next_target = "nunchuk landscape"
@@ -234,6 +236,7 @@ overlay2_desc12_overlay = ../flat/img/3d_rotate.png
 overlay2_desc12_range_mod = 30.0
 overlay2_desc12_saturate_pct = 0.65
 overlay2_desc12_movable = true
+overlay2_desc12_range_mod_exclusive = true
 
 # IR pointer
 overlay2_desc13 = "nul,0.850,0.92,radial,0.08,0.045"
@@ -243,6 +246,7 @@ overlay2_desc14_overlay = ../flat/img/finger.png
 overlay2_desc14_range_mod = 30.0
 overlay2_desc14_saturate_pct = 0.65
 overlay2_desc14_movable = true
+overlay2_desc14_range_mod_exclusive = true
 
 # rotate wiimote, home
 overlay2_desc15 = "overlay_next,0.70,0.55,radial,0.046296,0.02604"
@@ -351,6 +355,7 @@ overlay3_desc21_overlay = ../flat/img/3d_rotate.png
 overlay3_desc21_range_mod = 30.0
 overlay3_desc21_saturate_pct = 0.65
 overlay3_desc21_movable = true
+overlay3_desc21_range_mod_exclusive = true
 
 # plus
 overlay3_desc22 = "start,0.9575,0.44815,rect,0.02,0.035"
@@ -407,6 +412,7 @@ overlay5_desc12_overlay = ../flat/img/3d_rotate.png
 overlay5_desc12_range_mod = 30.0
 overlay5_desc12_saturate_pct = 0.65
 overlay5_desc12_movable = true
+overlay5_desc12_range_mod_exclusive = true
 
 # IR pointer
 overlay5_desc13 = "nul,0.850,0.92,radial,0.08,0.045"
@@ -516,6 +522,7 @@ overlay6_desc21_overlay = ../flat/img/gcn-thumbstick.png
 overlay6_desc21_range_mod = 30.0
 overlay6_desc21_saturate_pct = 0.65
 overlay6_desc21_movable = true
+overlay6_desc21_range_mod_exclusive = true
 
 # plus
 overlay6_desc22 = "r,0.7,0.94,rect,0.02,0.035"
@@ -529,6 +536,7 @@ overlay6_desc24_overlay = ../flat/img/finger.png
 overlay6_desc24_range_mod = 30.0
 overlay6_desc24_saturate_pct = 0.65
 overlay6_desc24_movable = true
+overlay6_desc24_range_mod_exclusive = true
 
 # nunchuk
 overlay6_desc25 = "x,0.125,0.60,radial,0.03,0.05"
@@ -592,6 +600,7 @@ overlay8_desc12_overlay = ../flat/img/gcn-thumbstick.png
 overlay8_desc12_range_mod = 30.0
 overlay8_desc12_saturate_pct = 0.65
 overlay8_desc12_movable = true
+overlay8_desc12_range_mod_exclusive = true
 
 # IR pointer
 overlay8_desc13 = "nul,0.850,0.92,radial,0.08,0.045"
@@ -601,6 +610,7 @@ overlay8_desc14_overlay = ../flat/img/finger.png
 overlay8_desc14_range_mod = 30.0
 overlay8_desc14_saturate_pct = 0.65
 overlay8_desc14_movable = true
+overlay8_desc14_range_mod_exclusive = true
 
 # remove nunchuk, home
 overlay8_desc15 = "overlay_next,0.60,0.55,radial,0.046296,0.02604"
@@ -654,6 +664,7 @@ overlay9_desc1_overlay = ../flat/img/gcn-thumbstick.png
 overlay9_desc1_range_mod = 30.0
 overlay9_desc1_saturate_pct = 0.65
 overlay9_desc1_movable = true
+overlay9_desc1_range_mod_exclusive = true
 
 overlay9_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay9_desc2_overlay = ../flat/img/A.png
@@ -690,6 +701,7 @@ overlay9_desc16_overlay = ../flat/img/gcn-thumbstick.png
 overlay9_desc16_range_mod = 30.0
 overlay9_desc16_saturate_pct = 0.65
 overlay9_desc16_movable = true
+overlay9_desc16_range_mod_exclusive = true
 
 overlay9_desc17 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay9_desc17_overlay = ../flat/img/rgui.png
@@ -762,6 +774,7 @@ overlay11_desc1_overlay = ../flat/img/gcn-thumbstick.png
 overlay11_desc1_range_mod = 30.0
 overlay11_desc1_saturate_pct = 0.65
 overlay11_desc1_movable = true
+overlay11_desc1_range_mod_exclusive = true
 
 overlay11_desc2 = "a,0.88889,0.85417,radial,0.07407,0.04167"
 overlay11_desc2_overlay = ../flat/img/A.png
@@ -885,6 +898,7 @@ overlay12_desc21_overlay = ../flat/img/gcn-thumbstick.png
 overlay12_desc21_range_mod = 30.0
 overlay12_desc21_saturate_pct = 0.65
 overlay12_desc21_movable = true
+overlay12_desc21_range_mod_exclusive = true
 
 # Z-trigger
 overlay12_desc22 = "r,0.92750,0.24815,rect,0.0708,0.045"
@@ -898,6 +912,7 @@ overlay12_desc24_overlay = ../flat/img/C.png
 overlay12_desc24_range_mod = 30.0
 overlay12_desc24_saturate_pct = 0.65
 overlay12_desc24_movable = true
+overlay12_desc24_range_mod_exclusive = true
 
 overlay12_desc25 = "overlay_next,0.70000,0.08889,radial,0.02604,0.046296"
 overlay12_desc25_next_target = "cc landscape"
@@ -953,6 +968,7 @@ overlay14_desc12_overlay = ../flat/img/gcn-thumbstick.png
 overlay14_desc12_range_mod = 30.0
 overlay14_desc12_saturate_pct = 0.65
 overlay14_desc12_movable = true
+overlay14_desc12_range_mod_exclusive = true
 
 # C-stick
 overlay14_desc13 = "nul,0.850,0.92,radial,0.11388,0.06406"
@@ -962,6 +978,7 @@ overlay14_desc14_overlay = ../flat/img/C.png
 overlay14_desc14_range_mod = 30.0
 overlay14_desc14_saturate_pct = 0.65
 overlay14_desc14_movable = true
+overlay14_desc14_range_mod_exclusive = true
 
 # analog L, R
 overlay14_desc15 = "l3,0.23125,0.58889,rect,0.14259,0.039"

--- a/gamepads/Named_Overlays/Nintendo - Wii.cfg
+++ b/gamepads/Named_Overlays/Nintendo - Wii.cfg
@@ -165,6 +165,7 @@ overlay0_desc21_overlay = ../flat/img/3d_rotate.png
 overlay0_desc21_range_mod = 30.0
 overlay0_desc21_saturate_pct = 0.65
 overlay0_desc21_movable = true
+overlay0_desc21_range_mod_exclusive = true
 
 # plus
 overlay0_desc22 = "start,0.9575,0.44815,rect,0.02,0.035"
@@ -178,6 +179,7 @@ overlay0_desc24_overlay = ../flat/img/finger.png
 overlay0_desc24_range_mod = 30.0
 overlay0_desc24_saturate_pct = 0.65
 overlay0_desc24_movable = true
+overlay0_desc24_range_mod_exclusive = true
 
 overlay0_desc25 = "overlay_next,0.80000,0.08889,radial,0.02604,0.046296"
 overlay0_desc25_next_target = "nunchuk landscape"
@@ -234,6 +236,7 @@ overlay2_desc12_overlay = ../flat/img/3d_rotate.png
 overlay2_desc12_range_mod = 30.0
 overlay2_desc12_saturate_pct = 0.65
 overlay2_desc12_movable = true
+overlay2_desc12_range_mod_exclusive = true
 
 # IR pointer
 overlay2_desc13 = "nul,0.850,0.92,radial,0.08,0.045"
@@ -243,6 +246,7 @@ overlay2_desc14_overlay = ../flat/img/finger.png
 overlay2_desc14_range_mod = 30.0
 overlay2_desc14_saturate_pct = 0.65
 overlay2_desc14_movable = true
+overlay2_desc14_range_mod_exclusive = true
 
 # rotate wiimote, home
 overlay2_desc15 = "overlay_next,0.70,0.55,radial,0.046296,0.02604"
@@ -351,6 +355,7 @@ overlay3_desc21_overlay = ../flat/img/3d_rotate.png
 overlay3_desc21_range_mod = 30.0
 overlay3_desc21_saturate_pct = 0.65
 overlay3_desc21_movable = true
+overlay3_desc21_range_mod_exclusive = true
 
 # plus
 overlay3_desc22 = "start,0.9575,0.44815,rect,0.02,0.035"
@@ -407,6 +412,7 @@ overlay5_desc12_overlay = ../flat/img/3d_rotate.png
 overlay5_desc12_range_mod = 30.0
 overlay5_desc12_saturate_pct = 0.65
 overlay5_desc12_movable = true
+overlay5_desc12_range_mod_exclusive = true
 
 # IR pointer
 overlay5_desc13 = "nul,0.850,0.92,radial,0.08,0.045"
@@ -516,6 +522,7 @@ overlay6_desc21_overlay = ../flat/img/gcn-thumbstick.png
 overlay6_desc21_range_mod = 30.0
 overlay6_desc21_saturate_pct = 0.65
 overlay6_desc21_movable = true
+overlay6_desc21_range_mod_exclusive = true
 
 # plus
 overlay6_desc22 = "r,0.7,0.94,rect,0.02,0.035"
@@ -529,6 +536,7 @@ overlay6_desc24_overlay = ../flat/img/finger.png
 overlay6_desc24_range_mod = 30.0
 overlay6_desc24_saturate_pct = 0.65
 overlay6_desc24_movable = true
+overlay6_desc24_range_mod_exclusive = true
 
 # nunchuk
 overlay6_desc25 = "x,0.125,0.60,radial,0.03,0.05"
@@ -592,6 +600,7 @@ overlay8_desc12_overlay = ../flat/img/gcn-thumbstick.png
 overlay8_desc12_range_mod = 30.0
 overlay8_desc12_saturate_pct = 0.65
 overlay8_desc12_movable = true
+overlay8_desc12_range_mod_exclusive = true
 
 # IR pointer
 overlay8_desc13 = "nul,0.850,0.92,radial,0.08,0.045"
@@ -601,6 +610,7 @@ overlay8_desc14_overlay = ../flat/img/finger.png
 overlay8_desc14_range_mod = 30.0
 overlay8_desc14_saturate_pct = 0.65
 overlay8_desc14_movable = true
+overlay8_desc14_range_mod_exclusive = true
 
 # remove nunchuk, home
 overlay8_desc15 = "overlay_next,0.60,0.55,radial,0.046296,0.02604"
@@ -654,6 +664,7 @@ overlay9_desc1_overlay = ../flat/img/gcn-thumbstick.png
 overlay9_desc1_range_mod = 30.0
 overlay9_desc1_saturate_pct = 0.65
 overlay9_desc1_movable = true
+overlay9_desc1_range_mod_exclusive = true
 
 overlay9_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay9_desc2_overlay = ../flat/img/A.png
@@ -690,6 +701,7 @@ overlay9_desc16_overlay = ../flat/img/gcn-thumbstick.png
 overlay9_desc16_range_mod = 30.0
 overlay9_desc16_saturate_pct = 0.65
 overlay9_desc16_movable = true
+overlay9_desc16_range_mod_exclusive = true
 
 overlay9_desc17 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay9_desc17_overlay = ../flat/img/rgui.png
@@ -762,6 +774,7 @@ overlay11_desc1_overlay = ../flat/img/gcn-thumbstick.png
 overlay11_desc1_range_mod = 30.0
 overlay11_desc1_saturate_pct = 0.65
 overlay11_desc1_movable = true
+overlay11_desc1_range_mod_exclusive = true
 
 overlay11_desc2 = "a,0.88889,0.85417,radial,0.07407,0.04167"
 overlay11_desc2_overlay = ../flat/img/A.png
@@ -885,6 +898,7 @@ overlay12_desc21_overlay = ../flat/img/gcn-thumbstick.png
 overlay12_desc21_range_mod = 30.0
 overlay12_desc21_saturate_pct = 0.65
 overlay12_desc21_movable = true
+overlay12_desc21_range_mod_exclusive = true
 
 # Z-trigger
 overlay12_desc22 = "r,0.92750,0.24815,rect,0.0708,0.045"
@@ -898,6 +912,7 @@ overlay12_desc24_overlay = ../flat/img/C.png
 overlay12_desc24_range_mod = 30.0
 overlay12_desc24_saturate_pct = 0.65
 overlay12_desc24_movable = true
+overlay12_desc24_range_mod_exclusive = true
 
 overlay12_desc25 = "overlay_next,0.70000,0.08889,radial,0.02604,0.046296"
 overlay12_desc25_next_target = "cc landscape"
@@ -953,6 +968,7 @@ overlay14_desc12_overlay = ../flat/img/gcn-thumbstick.png
 overlay14_desc12_range_mod = 30.0
 overlay14_desc12_saturate_pct = 0.65
 overlay14_desc12_movable = true
+overlay14_desc12_range_mod_exclusive = true
 
 # C-stick
 overlay14_desc13 = "nul,0.850,0.92,radial,0.11388,0.06406"
@@ -962,6 +978,7 @@ overlay14_desc14_overlay = ../flat/img/C.png
 overlay14_desc14_range_mod = 30.0
 overlay14_desc14_saturate_pct = 0.65
 overlay14_desc14_movable = true
+overlay14_desc14_range_mod_exclusive = true
 
 # analog L, R
 overlay14_desc15 = "l3,0.23125,0.58889,rect,0.14259,0.039"

--- a/gamepads/Named_Overlays/Sony - PlayStation 2.cfg
+++ b/gamepads/Named_Overlays/Sony - PlayStation 2.cfg
@@ -181,6 +181,7 @@ overlay1_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay1_desc1_range_mod = 30.0
 overlay1_desc1_saturate_pct = 0.65
 overlay1_desc1_movable = true
+overlay1_desc1_range_mod_exclusive = true
 
 overlay1_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay1_desc2_overlay = ../flat/img/circle.png
@@ -296,6 +297,7 @@ overlay2_desc22_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc22_range_mod = 30.0
 overlay2_desc22_saturate_pct = 0.65
 overlay2_desc22_movable = true
+overlay2_desc22_range_mod_exclusive = true
 
 overlay2_desc23 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay2_desc23_overlay = ../flat/img/rgui.png
@@ -341,6 +343,7 @@ overlay3_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay3_desc1_range_mod = 30.0
 overlay3_desc1_saturate_pct = 0.65
 overlay3_desc1_movable = true
+overlay3_desc1_range_mod_exclusive = true
 
 overlay3_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay3_desc2_overlay = ../flat/img/circle.png
@@ -377,6 +380,7 @@ overlay3_desc16_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay3_desc16_range_mod = 30.0
 overlay3_desc16_saturate_pct = 0.65
 overlay3_desc16_movable = true
+overlay3_desc16_range_mod_exclusive = true
 
 overlay3_desc17 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay3_desc17_overlay = ../flat/img/rgui.png
@@ -489,6 +493,7 @@ overlay5_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay5_desc1_range_mod = 30.0
 overlay5_desc1_saturate_pct = 0.65
 overlay5_desc1_movable = true
+overlay5_desc1_range_mod_exclusive = true
 
 overlay5_desc2 = "a,0.88889,0.85417,radial,0.07407,0.04167"
 overlay5_desc2_overlay = ../flat/img/circle.png
@@ -672,6 +677,7 @@ overlay11_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay11_desc1_range_mod = 30.0
 overlay11_desc1_saturate_pct = 0.65
 overlay11_desc1_movable = true
+overlay11_desc1_range_mod_exclusive = true
 
 overlay11_desc2 = "a,0.91979,0.72407,radial,0.05,0.08889"
 overlay11_desc2_overlay = ../flat/img/circle.png

--- a/gamepads/Named_Overlays/Sony - PlayStation 3 (PSN).cfg
+++ b/gamepads/Named_Overlays/Sony - PlayStation 3 (PSN).cfg
@@ -181,6 +181,7 @@ overlay1_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay1_desc1_range_mod = 30.0
 overlay1_desc1_saturate_pct = 0.65
 overlay1_desc1_movable = true
+overlay1_desc1_range_mod_exclusive = true
 
 overlay1_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay1_desc2_overlay = ../flat/img/circle.png
@@ -296,6 +297,7 @@ overlay2_desc22_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc22_range_mod = 30.0
 overlay2_desc22_saturate_pct = 0.65
 overlay2_desc22_movable = true
+overlay2_desc22_range_mod_exclusive = true
 
 overlay2_desc23 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay2_desc23_overlay = ../flat/img/rgui.png
@@ -341,6 +343,7 @@ overlay3_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay3_desc1_range_mod = 30.0
 overlay3_desc1_saturate_pct = 0.65
 overlay3_desc1_movable = true
+overlay3_desc1_range_mod_exclusive = true
 
 overlay3_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay3_desc2_overlay = ../flat/img/circle.png
@@ -377,6 +380,7 @@ overlay3_desc16_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay3_desc16_range_mod = 30.0
 overlay3_desc16_saturate_pct = 0.65
 overlay3_desc16_movable = true
+overlay3_desc16_range_mod_exclusive = true
 
 overlay3_desc17 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay3_desc17_overlay = ../flat/img/rgui.png
@@ -489,6 +493,7 @@ overlay5_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay5_desc1_range_mod = 30.0
 overlay5_desc1_saturate_pct = 0.65
 overlay5_desc1_movable = true
+overlay5_desc1_range_mod_exclusive = true
 
 overlay5_desc2 = "a,0.88889,0.85417,radial,0.07407,0.04167"
 overlay5_desc2_overlay = ../flat/img/circle.png
@@ -672,6 +677,7 @@ overlay11_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay11_desc1_range_mod = 30.0
 overlay11_desc1_saturate_pct = 0.65
 overlay11_desc1_movable = true
+overlay11_desc1_range_mod_exclusive = true
 
 overlay11_desc2 = "a,0.91979,0.72407,radial,0.05,0.08889"
 overlay11_desc2_overlay = ../flat/img/circle.png

--- a/gamepads/Named_Overlays/Sony - PlayStation 3.cfg
+++ b/gamepads/Named_Overlays/Sony - PlayStation 3.cfg
@@ -181,6 +181,7 @@ overlay1_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay1_desc1_range_mod = 30.0
 overlay1_desc1_saturate_pct = 0.65
 overlay1_desc1_movable = true
+overlay1_desc1_range_mod_exclusive = true
 
 overlay1_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay1_desc2_overlay = ../flat/img/circle.png
@@ -296,6 +297,7 @@ overlay2_desc22_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc22_range_mod = 30.0
 overlay2_desc22_saturate_pct = 0.65
 overlay2_desc22_movable = true
+overlay2_desc22_range_mod_exclusive = true
 
 overlay2_desc23 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay2_desc23_overlay = ../flat/img/rgui.png
@@ -341,6 +343,7 @@ overlay3_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay3_desc1_range_mod = 30.0
 overlay3_desc1_saturate_pct = 0.65
 overlay3_desc1_movable = true
+overlay3_desc1_range_mod_exclusive = true
 
 overlay3_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay3_desc2_overlay = ../flat/img/circle.png
@@ -377,6 +380,7 @@ overlay3_desc16_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay3_desc16_range_mod = 30.0
 overlay3_desc16_saturate_pct = 0.65
 overlay3_desc16_movable = true
+overlay3_desc16_range_mod_exclusive = true
 
 overlay3_desc17 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay3_desc17_overlay = ../flat/img/rgui.png
@@ -489,6 +493,7 @@ overlay5_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay5_desc1_range_mod = 30.0
 overlay5_desc1_saturate_pct = 0.65
 overlay5_desc1_movable = true
+overlay5_desc1_range_mod_exclusive = true
 
 overlay5_desc2 = "a,0.88889,0.85417,radial,0.07407,0.04167"
 overlay5_desc2_overlay = ../flat/img/circle.png
@@ -672,6 +677,7 @@ overlay11_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay11_desc1_range_mod = 30.0
 overlay11_desc1_saturate_pct = 0.65
 overlay11_desc1_movable = true
+overlay11_desc1_range_mod_exclusive = true
 
 overlay11_desc2 = "a,0.91979,0.72407,radial,0.05,0.08889"
 overlay11_desc2_overlay = ../flat/img/circle.png

--- a/gamepads/Named_Overlays/Sony - PlayStation Portable (PSN).cfg
+++ b/gamepads/Named_Overlays/Sony - PlayStation Portable (PSN).cfg
@@ -83,6 +83,7 @@ overlay0_desc20_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay0_desc20_range_mod = 30.0
 overlay0_desc20_saturate_pct = 0.65
 overlay0_desc20_movable = true
+overlay0_desc20_range_mod_exclusive = true
 
 overlay0_desc21 = "l|r,0.11458,0.94815,rect,0.06458,0.09259"
 overlay0_desc21_overlay = ../flat/img/L_and_R_down.png
@@ -165,6 +166,7 @@ overlay1_desc20_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay1_desc20_range_mod = 30.0
 overlay1_desc20_saturate_pct = 0.65
 overlay1_desc20_movable = true
+overlay1_desc20_range_mod_exclusive = true
 
 overlay1_desc21 = "l|r,0.16042,0.10000,rect,0.05417,0.05370"
 overlay1_desc21_overlay = ../flat/img/L_and_R.png
@@ -245,6 +247,7 @@ overlay2_desc20_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc20_range_mod = 30.0
 overlay2_desc20_saturate_pct = 0.65
 overlay2_desc20_movable = true
+overlay2_desc20_range_mod_exclusive = true
 
 overlay2_desc21 = "l|r,0.28519,0.45417,rect,0.096296,0.03021"
 overlay2_desc21_overlay = ../flat/img/L_and_R.png

--- a/gamepads/Named_Overlays/Sony - PlayStation Portable.cfg
+++ b/gamepads/Named_Overlays/Sony - PlayStation Portable.cfg
@@ -83,6 +83,7 @@ overlay0_desc20_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay0_desc20_range_mod = 30.0
 overlay0_desc20_saturate_pct = 0.65
 overlay0_desc20_movable = true
+overlay0_desc20_range_mod_exclusive = true
 
 overlay0_desc21 = "l|r,0.11458,0.94815,rect,0.06458,0.09259"
 overlay0_desc21_overlay = ../flat/img/L_and_R_down.png
@@ -165,6 +166,7 @@ overlay1_desc20_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay1_desc20_range_mod = 30.0
 overlay1_desc20_saturate_pct = 0.65
 overlay1_desc20_movable = true
+overlay1_desc20_range_mod_exclusive = true
 
 overlay1_desc21 = "l|r,0.16042,0.10000,rect,0.05417,0.05370"
 overlay1_desc21_overlay = ../flat/img/L_and_R.png
@@ -245,6 +247,7 @@ overlay2_desc20_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc20_range_mod = 30.0
 overlay2_desc20_saturate_pct = 0.65
 overlay2_desc20_movable = true
+overlay2_desc20_range_mod_exclusive = true
 
 overlay2_desc21 = "l|r,0.28519,0.45417,rect,0.096296,0.03021"
 overlay2_desc21_overlay = ../flat/img/L_and_R.png

--- a/gamepads/Named_Overlays/Sony - PlayStation.cfg
+++ b/gamepads/Named_Overlays/Sony - PlayStation.cfg
@@ -181,6 +181,7 @@ overlay1_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay1_desc1_range_mod = 30.0
 overlay1_desc1_saturate_pct = 0.65
 overlay1_desc1_movable = true
+overlay1_desc1_range_mod_exclusive = true
 
 overlay1_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay1_desc2_overlay = ../flat/img/circle.png
@@ -296,6 +297,7 @@ overlay2_desc22_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay2_desc22_range_mod = 30.0
 overlay2_desc22_saturate_pct = 0.65
 overlay2_desc22_movable = true
+overlay2_desc22_range_mod_exclusive = true
 
 overlay2_desc23 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay2_desc23_overlay = ../flat/img/rgui.png
@@ -341,6 +343,7 @@ overlay3_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay3_desc1_range_mod = 30.0
 overlay3_desc1_saturate_pct = 0.65
 overlay3_desc1_movable = true
+overlay3_desc1_range_mod_exclusive = true
 
 overlay3_desc2 = "a,0.93750,0.77778,radial,0.04167,0.07407"
 overlay3_desc2_overlay = ../flat/img/circle.png
@@ -377,6 +380,7 @@ overlay3_desc16_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay3_desc16_range_mod = 30.0
 overlay3_desc16_saturate_pct = 0.65
 overlay3_desc16_movable = true
+overlay3_desc16_range_mod_exclusive = true
 
 overlay3_desc17 = "menu_toggle,0.50000,0.08889,radial,0.02604,0.046296"
 overlay3_desc17_overlay = ../flat/img/rgui.png
@@ -489,6 +493,7 @@ overlay5_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay5_desc1_range_mod = 30.0
 overlay5_desc1_saturate_pct = 0.65
 overlay5_desc1_movable = true
+overlay5_desc1_range_mod_exclusive = true
 
 overlay5_desc2 = "a,0.88889,0.85417,radial,0.07407,0.04167"
 overlay5_desc2_overlay = ../flat/img/circle.png
@@ -672,6 +677,7 @@ overlay11_desc1_overlay = ../flat/img/thumbstick-pad_arcade.png
 overlay11_desc1_range_mod = 30.0
 overlay11_desc1_saturate_pct = 0.65
 overlay11_desc1_movable = true
+overlay11_desc1_range_mod_exclusive = true
 
 overlay11_desc2 = "a,0.91979,0.72407,radial,0.05,0.08889"
 overlay11_desc2_overlay = ../flat/img/circle.png


### PR DESCRIPTION
the directions weren't correctly rotated to match the physical orientation of the simulated wiimote.